### PR TITLE
Prototype an approach to field aliases that creates a new top-level mapper type.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -459,13 +459,15 @@ final class DocumentParser {
     private static void parseObjectOrField(ParseContext context, Mapper mapper) throws IOException {
         if (mapper instanceof ObjectMapper) {
             parseObjectOrNested(context, (ObjectMapper) mapper);
-        } else {
-            FieldMapper fieldMapper = (FieldMapper)mapper;
+        } else if (mapper instanceof FieldMapper) {
+            FieldMapper fieldMapper = (FieldMapper) mapper;
             Mapper update = fieldMapper.parse(context);
             if (update != null) {
                 context.addDynamicMapper(update);
             }
             parseCopyFields(context, fieldMapper.copyTo().copyToFields());
+        } else {
+            throw new IllegalArgumentException("Cannot write to a field alias [" + mapper.name() + "].");
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+public class FieldAliasMapper extends Mapper {
+    public static final String CONTENT_TYPE = "alias";
+
+    public static class Names {
+        public static final String PATH = "path";
+    }
+
+    private final String name;
+    private final String path;
+
+    public FieldAliasMapper(String simpleName,
+                            String name,
+                            String path) {
+        super(simpleName);
+        this.name = name;
+        this.path = path;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    public String path() {
+        return path;
+    }
+
+    @Override
+    public Mapper merge(Mapper mergeWith) {
+        if (!(mergeWith instanceof FieldAliasMapper)) {
+            throw new IllegalArgumentException("Cannot merge a field alias [" + name() +
+                "] with a mapping that is not an alias [" + mergeWith.name() + "].");
+        }
+        return mergeWith;
+    }
+
+    @Override
+    public Mapper updateFieldType(Map<String, MappedFieldType> fullNameToFieldType) {
+        return this;
+    }
+
+    @Override
+    public Iterator<Mapper> iterator() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject(simpleName())
+            .field("type", CONTENT_TYPE)
+            .field(Names.PATH, path)
+            .endObject();
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+        @Override
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext)
+            throws MapperParsingException {
+            FieldAliasMapper.Builder builder = new FieldAliasMapper.Builder(name);
+            Object pathField = node.remove(Names.PATH);
+            String path = XContentMapValues.nodeStringValue(pathField, null);
+            if (path == null) {
+                throw new IllegalArgumentException("The [path] property must be specified.");
+            }
+            return builder.path(path);
+        }
+    }
+
+    public static class Builder extends Mapper.Builder<FieldAliasMapper.Builder, FieldAliasMapper> {
+        private String name;
+        private String path;
+
+        protected Builder(String name) {
+            super(name);
+            this.name = name;
+        }
+
+        public String name() {
+            return this.name;
+        }
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public FieldAliasMapper build(BuilderContext context) {
+            String fullName = context.path().pathAsText(name);
+            return new FieldAliasMapper(name, fullName, path);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -128,11 +127,9 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
                 fields.add(fieldType.name());
             }
         }
-        for (Map.Entry<String, String> entry : aliasToFullName.entrySet()) {
-            String aliasName = entry.getKey();
-            String fieldName = entry.getValue();
+        for (String aliasName : aliasToFullName.keySet()) {
             if (Regex.simpleMatch(pattern, aliasName)) {
-                fields.add(fieldName);
+                fields.add(aliasName);
             }
         }
         return fields;

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.hppc.ObjectHashSet;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
-
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
@@ -395,15 +394,17 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             // check basic sanity of the new mapping
             List<ObjectMapper> objectMappers = new ArrayList<>();
             List<FieldMapper> fieldMappers = new ArrayList<>();
+            List<FieldAliasMapper> fieldAliasMappers = new ArrayList<>();
             Collections.addAll(fieldMappers, newMapper.mapping().metadataMappers);
-            MapperUtils.collect(newMapper.mapping().root(), objectMappers, fieldMappers);
+            MapperUtils.collect(newMapper.mapping().root(), objectMappers, fieldMappers, fieldAliasMappers);
             checkFieldUniqueness(newMapper.type(), objectMappers, fieldMappers, fullPathObjectMappers, fieldTypes);
             checkObjectsCompatibility(objectMappers, fullPathObjectMappers);
             checkPartitionedIndexConstraints(newMapper);
+            // TODO: check aliases are valid here?
 
             // update lookup data-structures
             // this will in particular make sure that the merged fields are compatible with other types
-            fieldTypes = fieldTypes.copyAndAddAll(newMapper.type(), fieldMappers);
+            fieldTypes = fieldTypes.copyAndAddAll(newMapper.type(), fieldMappers, fieldAliasMappers);
 
             for (ObjectMapper objectMapper : objectMappers) {
                 if (fullPathObjectMappers == this.fullPathObjectMappers) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperUtils.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperUtils.java
@@ -19,22 +19,32 @@
 
 package org.elasticsearch.index.mapper;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 enum MapperUtils {
     ;
 
     /** Split mapper and its descendants into object and field mappers. */
-    public static void collect(Mapper mapper, Collection<ObjectMapper> objectMappers, Collection<FieldMapper> fieldMappers) {
+    public static void collect(Mapper mapper, Collection<ObjectMapper> objectMappers,
+                               Collection<FieldMapper> fieldMappers) {
+        collect(mapper, objectMappers, fieldMappers, new ArrayList<>());
+    }
+
+    public static void collect(Mapper mapper, Collection<ObjectMapper> objectMappers,
+                               Collection<FieldMapper> fieldMappers,
+                               Collection<FieldAliasMapper> fieldAliasMappers) {
         if (mapper instanceof RootObjectMapper) {
             // root mapper isn't really an object mapper
         } else if (mapper instanceof ObjectMapper) {
             objectMappers.add((ObjectMapper)mapper);
         } else if (mapper instanceof FieldMapper) {
             fieldMappers.add((FieldMapper)mapper);
+        } else if (mapper instanceof FieldAliasMapper) {
+            fieldAliasMappers.add((FieldAliasMapper) mapper);
         }
         for (Mapper child : mapper) {
-            collect(child, objectMappers, fieldMappers);
+            collect(child, objectMappers, fieldMappers, fieldAliasMappers);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.resync.TransportResyncReplicationAction;
 import org.elasticsearch.common.geo.ShapesAvailability;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry.Entry;
+import org.elasticsearch.index.mapper.FieldAliasMapper;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.CompletionFieldMapper;
@@ -111,6 +112,8 @@ public class IndicesModule extends AbstractModule {
         mappers.put(ObjectMapper.NESTED_CONTENT_TYPE, new ObjectMapper.TypeParser());
         mappers.put(CompletionFieldMapper.CONTENT_TYPE, new CompletionFieldMapper.TypeParser());
         mappers.put(GeoPointFieldMapper.CONTENT_TYPE, new GeoPointFieldMapper.TypeParser());
+        mappers.put(FieldAliasMapper.CONTENT_TYPE, new FieldAliasMapper.TypeParser());
+
         if (ShapesAvailability.JTS_AVAILABLE && ShapesAvailability.SPATIAL4J_AVAILABLE) {
             mappers.put(GeoShapeFieldMapper.CONTENT_TYPE, new GeoShapeFieldMapper.TypeParser());
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -63,8 +63,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.contentBuilder;
-
 /**
  * Fetch phase of a search request, used to fetch the actual top matching documents to be returned to the client, identified
  * after reducing all of the matches returned by the query phase
@@ -118,11 +116,12 @@ public class FetchPhase implements SearchPhase {
                         if (context.getObjectMapper(fieldName) != null) {
                             throw new IllegalArgumentException("field [" + fieldName + "] isn't a leaf field");
                         }
+                    } else {
+                        if (fieldNames == null) {
+                            fieldNames = new HashSet<>();
+                        }
+                        fieldNames.add(fieldType.name());
                     }
-                    if (fieldNames == null) {
-                        fieldNames = new HashSet<>();
-                    }
-                    fieldNames.add(fieldName);
                 }
             }
             boolean loadSource = context.sourceRequested();

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FastVectorHighlighter.java
@@ -36,7 +36,7 @@ import org.apache.lucene.search.vectorhighlight.SingleFragListBuilder;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.text.Text;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.fetch.FetchPhaseExecutionException;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchContextHighlight.Field;
@@ -71,9 +71,9 @@ public class FastVectorHighlighter implements Highlighter {
         SearchContextHighlight.Field field = highlighterContext.field;
         SearchContext context = highlighterContext.context;
         FetchSubPhase.HitContext hitContext = highlighterContext.hitContext;
-        FieldMapper mapper = highlighterContext.mapper;
+        MappedFieldType fieldType = highlighterContext.fieldType;
 
-        if (canHighlight(mapper) == false) {
+        if (canHighlight(fieldType) == false) {
             throw new IllegalArgumentException("the field [" + highlighterContext.fieldName +
                 "] should be indexed with term vector with position offsets to be used with fast vector highlighter");
         }
@@ -87,7 +87,7 @@ public class FastVectorHighlighter implements Highlighter {
         HighlighterEntry cache = (HighlighterEntry) hitContext.cache().get(CACHE_KEY);
 
         try {
-            MapperHighlightEntry entry = cache.mappers.get(mapper);
+            FieldHighlightEntry entry = cache.entries.get(fieldType);
             if (entry == null) {
                 FragListBuilder fragListBuilder;
                 BaseFragmentsBuilder fragmentsBuilder;
@@ -97,37 +97,37 @@ public class FastVectorHighlighter implements Highlighter {
                 if (field.fieldOptions().numberOfFragments() == 0) {
                     fragListBuilder = new SingleFragListBuilder();
 
-                    if (!forceSource && mapper.fieldType().stored()) {
-                        fragmentsBuilder = new SimpleFragmentsBuilder(mapper, field.fieldOptions().preTags(),
+                    if (!forceSource && fieldType.stored()) {
+                        fragmentsBuilder = new SimpleFragmentsBuilder(fieldType, field.fieldOptions().preTags(),
                                 field.fieldOptions().postTags(), boundaryScanner);
                     } else {
-                        fragmentsBuilder = new SourceSimpleFragmentsBuilder(mapper, context,
+                        fragmentsBuilder = new SourceSimpleFragmentsBuilder(fieldType, context,
                                 field.fieldOptions().preTags(), field.fieldOptions().postTags(), boundaryScanner);
                     }
                 } else {
                     fragListBuilder = field.fieldOptions().fragmentOffset() == -1 ?
                         new SimpleFragListBuilder() : new SimpleFragListBuilder(field.fieldOptions().fragmentOffset());
                     if (field.fieldOptions().scoreOrdered()) {
-                        if (!forceSource && mapper.fieldType().stored()) {
+                        if (!forceSource && fieldType.stored()) {
                             fragmentsBuilder = new ScoreOrderFragmentsBuilder(field.fieldOptions().preTags(),
                                     field.fieldOptions().postTags(), boundaryScanner);
                         } else {
-                            fragmentsBuilder = new SourceScoreOrderFragmentsBuilder(mapper, context,
+                            fragmentsBuilder = new SourceScoreOrderFragmentsBuilder(fieldType, context,
                                     field.fieldOptions().preTags(), field.fieldOptions().postTags(), boundaryScanner);
                         }
                     } else {
-                        if (!forceSource && mapper.fieldType().stored()) {
-                            fragmentsBuilder = new SimpleFragmentsBuilder(mapper, field.fieldOptions().preTags(),
+                        if (!forceSource && fieldType.stored()) {
+                            fragmentsBuilder = new SimpleFragmentsBuilder(fieldType, field.fieldOptions().preTags(),
                                     field.fieldOptions().postTags(), boundaryScanner);
                         } else {
                             fragmentsBuilder =
-                                new SourceSimpleFragmentsBuilder(mapper, context, field.fieldOptions().preTags(),
+                                new SourceSimpleFragmentsBuilder(fieldType, context, field.fieldOptions().preTags(),
                                     field.fieldOptions().postTags(), boundaryScanner);
                         }
                     }
                 }
                 fragmentsBuilder.setDiscreteMultiValueHighlighting(termVectorMultiValue);
-                entry = new MapperHighlightEntry();
+                entry = new FieldHighlightEntry();
                 if (field.fieldOptions().requireFieldMatch()) {
                     /**
                      * we use top level reader to rewrite the query against all readers,
@@ -152,7 +152,7 @@ public class FastVectorHighlighter implements Highlighter {
                     cache.fvh = new org.apache.lucene.search.vectorhighlight.FastVectorHighlighter();
                 }
                 CustomFieldQuery.highlightFilters.set(field.fieldOptions().highlightFilter());
-                cache.mappers.put(mapper, entry);
+                cache.entries.put(fieldType, entry);
             }
             final FieldQuery fieldQuery;
             if (field.fieldOptions().requireFieldMatch()) {
@@ -173,12 +173,12 @@ public class FastVectorHighlighter implements Highlighter {
             // Only send matched fields if they were requested to save time.
             if (field.fieldOptions().matchedFields() != null && !field.fieldOptions().matchedFields().isEmpty()) {
                 fragments = cache.fvh.getBestFragments(fieldQuery, hitContext.reader(), hitContext.docId(),
-                    mapper.fieldType().name(), field.fieldOptions().matchedFields(), fragmentCharSize,
+                    fieldType.name(), field.fieldOptions().matchedFields(), fragmentCharSize,
                     numberOfFragments, entry.fragListBuilder, entry.fragmentsBuilder, field.fieldOptions().preTags(),
                     field.fieldOptions().postTags(), encoder);
             } else {
                 fragments = cache.fvh.getBestFragments(fieldQuery, hitContext.reader(), hitContext.docId(),
-                    mapper.fieldType().name(), fragmentCharSize, numberOfFragments, entry.fragListBuilder,
+                    fieldType.name(), fragmentCharSize, numberOfFragments, entry.fragListBuilder,
                     entry.fragmentsBuilder, field.fieldOptions().preTags(), field.fieldOptions().postTags(), encoder);
             }
 
@@ -193,7 +193,7 @@ public class FastVectorHighlighter implements Highlighter {
                 FieldFragList fieldFragList = new SimpleFieldFragList(-1 /*ignored*/);
                 fieldFragList.add(0, noMatchSize, Collections.<WeightedPhraseInfo>emptyList());
                 fragments = entry.fragmentsBuilder.createFragments(hitContext.reader(), hitContext.docId(),
-                    mapper.fieldType().name(), fieldFragList, 1, field.fieldOptions().preTags(),
+                    fieldType.name(), fieldFragList, 1, field.fieldOptions().preTags(),
                     field.fieldOptions().postTags(), encoder);
                 if (fragments != null && fragments.length > 0) {
                     return new HighlightField(highlighterContext.fieldName, Text.convertFromStringArray(fragments));
@@ -209,9 +209,10 @@ public class FastVectorHighlighter implements Highlighter {
     }
 
     @Override
-    public boolean canHighlight(FieldMapper fieldMapper) {
-        return fieldMapper.fieldType().storeTermVectors() && fieldMapper.fieldType().storeTermVectorOffsets()
-                && fieldMapper.fieldType().storeTermVectorPositions();
+    public boolean canHighlight(MappedFieldType fieldType) {
+        return fieldType.storeTermVectors()
+            && fieldType.storeTermVectorOffsets()
+            && fieldType.storeTermVectorPositions();
     }
 
     private static BoundaryScanner getBoundaryScanner(Field field) {
@@ -244,7 +245,7 @@ public class FastVectorHighlighter implements Highlighter {
         }
     }
 
-    private class MapperHighlightEntry {
+    private class FieldHighlightEntry {
         public FragListBuilder fragListBuilder;
         public FragmentsBuilder fragmentsBuilder;
         public FieldQuery noFieldMatchFieldQuery;
@@ -253,6 +254,6 @@ public class FastVectorHighlighter implements Highlighter {
 
     private class HighlighterEntry {
         public org.apache.lucene.search.vectorhighlight.FastVectorHighlighter fvh;
-        public Map<FieldMapper, MapperHighlightEntry> mappers = new HashMap<>();
+        public Map<MappedFieldType, FieldHighlightEntry> entries = new HashMap<>();
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FragmentBuilderHelper.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/FragmentBuilderHelper.java
@@ -29,7 +29,7 @@ import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.index.analysis.CustomAnalyzer;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.util.Comparator;
 import java.util.List;
@@ -47,10 +47,10 @@ public final class FragmentBuilderHelper {
      * Fixes problems with broken analysis chains if positions and offsets are messed up that can lead to
      * {@link StringIndexOutOfBoundsException} in the {@link FastVectorHighlighter}
      */
-    public static WeightedFragInfo fixWeightedFragInfo(FieldMapper mapper, Field[] values, WeightedFragInfo fragInfo) {
+    public static WeightedFragInfo fixWeightedFragInfo(MappedFieldType fieldType, Field[] values, WeightedFragInfo fragInfo) {
         assert fragInfo != null : "FragInfo must not be null";
-        assert mapper.fieldType().name().equals(values[0].name()) : "Expected FieldMapper for field " + values[0].name();
-        if (!fragInfo.getSubInfos().isEmpty() && containsBrokenAnalysis(mapper.fieldType().indexAnalyzer())) {
+        assert fieldType.name().equals(values[0].name()) : "Expected MappedFieldType for field " + values[0].name();
+        if (!fragInfo.getSubInfos().isEmpty() && containsBrokenAnalysis(fieldType.indexAnalyzer())) {
             /* This is a special case where broken analysis like WDF is used for term-vector creation at index-time
              * which can potentially mess up the offsets. To prevent a SAIIOBException we need to resort
              * the fragments based on their offsets rather than using soley the positions as it is done in

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightPhase.java
@@ -102,7 +102,7 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
                 if (highlightQuery == null) {
                     highlightQuery = context.parsedQuery().query();
                 }
-                HighlighterContext highlighterContext = new HighlighterContext(fieldName,
+                HighlighterContext highlighterContext = new HighlighterContext(fieldType.name(),
                     field, fieldType, context, hitContext, highlightQuery);
 
                 if ((highlighter.canHighlight(fieldType) == false) && fieldNameContainsWildcards) {
@@ -111,7 +111,10 @@ public class HighlightPhase extends AbstractComponent implements FetchSubPhase {
                 }
                 HighlightField highlightField = highlighter.highlight(highlighterContext);
                 if (highlightField != null) {
-                    highlightFields.put(highlightField.name(), highlightField);
+                    // Note that we must make sure to use the original field name in the
+                    // response, as this field could be an alias.
+                    highlightFields.put(fieldName,
+                        new HighlightField(fieldName, highlightField.fragments()));
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/Highlighter.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/Highlighter.java
@@ -18,7 +18,7 @@
  */
 package org.elasticsearch.search.fetch.subphase.highlight;
 
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 /**
  * Highlights a search result.
@@ -27,5 +27,5 @@ public interface Highlighter {
 
     HighlightField highlight(HighlighterContext highlighterContext);
 
-    boolean canHighlight(FieldMapper fieldMapper);
+    boolean canHighlight(MappedFieldType fieldType);
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterContext.java
@@ -19,7 +19,7 @@
 package org.elasticsearch.search.fetch.subphase.highlight;
 
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.internal.SearchContext;
 
@@ -27,16 +27,20 @@ public class HighlighterContext {
 
     public final String fieldName;
     public final SearchContextHighlight.Field field;
-    public final FieldMapper mapper;
+    public final MappedFieldType fieldType;
     public final SearchContext context;
     public final FetchSubPhase.HitContext hitContext;
     public final Query query;
 
-    public HighlighterContext(String fieldName, SearchContextHighlight.Field field, FieldMapper mapper, SearchContext context,
-            FetchSubPhase.HitContext hitContext, Query query) {
+    public HighlighterContext(String fieldName,
+                              SearchContextHighlight.Field field,
+                              MappedFieldType fieldType,
+                              SearchContext context,
+                              FetchSubPhase.HitContext hitContext,
+                              Query query) {
         this.fieldName = fieldName;
         this.field = field;
-        this.mapper = mapper;
+        this.fieldType = fieldType;
         this.context = context;
         this.hitContext = hitContext;
         this.query = query;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SimpleFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SimpleFragmentsBuilder.java
@@ -23,24 +23,27 @@ import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
 import org.apache.lucene.search.vectorhighlight.FieldFragList.WeightedFragInfo;
 import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 /**
- * Direct Subclass of Lucene's org.apache.lucene.search.vectorhighlight.SimpleFragmentsBuilder 
- * that corrects offsets for broken analysis chains. 
+ * Direct Subclass of Lucene's org.apache.lucene.search.vectorhighlight.SimpleFragmentsBuilder
+ * that corrects offsets for broken analysis chains.
  */
 public class SimpleFragmentsBuilder extends org.apache.lucene.search.vectorhighlight.SimpleFragmentsBuilder {
-    protected final FieldMapper mapper;
+    protected final MappedFieldType fieldType;
 
-    public SimpleFragmentsBuilder(FieldMapper mapper,
-                                        String[] preTags, String[] postTags, BoundaryScanner boundaryScanner) {
+    public SimpleFragmentsBuilder(MappedFieldType fieldType,
+                                  String[] preTags,
+                                  String[] postTags,
+                                  BoundaryScanner boundaryScanner) {
         super(preTags, postTags, boundaryScanner);
-        this.mapper = mapper;
+        this.fieldType = fieldType;
     }
-    
+
     @Override
     protected String makeFragment( StringBuilder buffer, int[] index, Field[] values, WeightedFragInfo fragInfo,
             String[] preTags, String[] postTags, Encoder encoder ){
-        return super.makeFragment(buffer, index, values, FragmentBuilderHelper.fixWeightedFragInfo(mapper, values, fragInfo),
-                preTags, postTags, encoder);
+        WeightedFragInfo weightedFragInfo = FragmentBuilderHelper.fixWeightedFragInfo(fieldType, values, fragInfo);
+        return super.makeFragment(buffer, index, values, weightedFragInfo, preTags, postTags, encoder);
    }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceScoreOrderFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceScoreOrderFragmentsBuilder.java
@@ -26,7 +26,7 @@ import org.apache.lucene.search.highlight.Encoder;
 import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
 import org.apache.lucene.search.vectorhighlight.FieldFragList.WeightedFragInfo;
 import org.apache.lucene.search.vectorhighlight.ScoreOrderFragmentsBuilder;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
@@ -35,14 +35,17 @@ import java.util.List;
 
 public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder {
 
-    private final FieldMapper mapper;
+    private final MappedFieldType fieldType;
 
     private final SearchContext searchContext;
 
-    public SourceScoreOrderFragmentsBuilder(FieldMapper mapper, SearchContext searchContext, String[] preTags, String[] postTags,
+    public SourceScoreOrderFragmentsBuilder(MappedFieldType fieldType,
+                                            SearchContext searchContext,
+                                            String[] preTags,
+                                            String[] postTags,
                                             BoundaryScanner boundaryScanner) {
         super(preTags, postTags, boundaryScanner);
-        this.mapper = mapper;
+        this.fieldType = fieldType;
         this.searchContext = searchContext;
     }
 
@@ -52,10 +55,10 @@ public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder
         SourceLookup sourceLookup = searchContext.lookup().source();
         sourceLookup.setSegmentAndDocument((LeafReaderContext) reader.getContext(), docId);
 
-        List<Object> values = sourceLookup.extractRawValues(mapper.fieldType().name());
+        List<Object> values = sourceLookup.extractRawValues(fieldType.name());
         Field[] fields = new Field[values.size()];
         for (int i = 0; i < values.size(); i++) {
-            fields[i] = new Field(mapper.fieldType().name(), values.get(i).toString(), TextField.TYPE_NOT_STORED);
+            fields[i] = new Field(fieldType.name(), values.get(i).toString(), TextField.TYPE_NOT_STORED);
         }
         return fields;
     }
@@ -63,7 +66,7 @@ public class SourceScoreOrderFragmentsBuilder extends ScoreOrderFragmentsBuilder
     @Override
     protected String makeFragment( StringBuilder buffer, int[] index, Field[] values, WeightedFragInfo fragInfo,
             String[] preTags, String[] postTags, Encoder encoder ){
-        return super.makeFragment(buffer, index, values, FragmentBuilderHelper.fixWeightedFragInfo(mapper, values, fragInfo),
-                preTags, postTags, encoder);
+        WeightedFragInfo weightedFragInfo = FragmentBuilderHelper.fixWeightedFragInfo(fieldType, values, fragInfo);
+        return super.makeFragment(buffer, index, values, weightedFragInfo, preTags, postTags, encoder);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceSimpleFragmentsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SourceSimpleFragmentsBuilder.java
@@ -23,7 +23,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.vectorhighlight.BoundaryScanner;
-import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.lookup.SourceLookup;
 
@@ -34,9 +34,12 @@ public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
 
     private final SearchContext searchContext;
 
-    public SourceSimpleFragmentsBuilder(FieldMapper mapper, SearchContext searchContext, String[] preTags, String[] postTags,
+    public SourceSimpleFragmentsBuilder(MappedFieldType fieldType,
+                                        SearchContext searchContext,
+                                        String[] preTags,
+                                        String[] postTags,
                                         BoundaryScanner boundaryScanner) {
-        super(mapper, preTags, postTags, boundaryScanner);
+        super(fieldType, preTags, postTags, boundaryScanner);
         this.searchContext = searchContext;
     }
 
@@ -48,13 +51,13 @@ public class SourceSimpleFragmentsBuilder extends SimpleFragmentsBuilder {
         SourceLookup sourceLookup = searchContext.lookup().source();
         sourceLookup.setSegmentAndDocument((LeafReaderContext) reader.getContext(), docId);
 
-        List<Object> values = sourceLookup.extractRawValues(mapper.fieldType().name());
+        List<Object> values = sourceLookup.extractRawValues(fieldType.name());
         if (values.isEmpty()) {
             return EMPTY_FIELDS;
         }
         Field[] fields = new Field[values.size()];
         for (int i = 0; i < values.size(); i++) {
-            fields[i] = new Field(mapper.fieldType().name(), values.get(i).toString(), TextField.TYPE_NOT_STORED);
+            fields[i] = new Field(fieldType.name(), values.get(i).toString(), TextField.TYPE_NOT_STORED);
         }
         return fields;
     }

--- a/server/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/SuggestionBuilder.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.BytesRefs;
-import org.elasticsearch.common.xcontent.ToXContent.Params;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -321,7 +320,7 @@ public abstract class SuggestionBuilder<T extends SuggestionBuilder<T>> implemen
             suggestionContext.setAnalyzer(luceneAnalyzer);
         }
 
-        suggestionContext.setField(field);
+        suggestionContext.setField(fieldType.name());
 
         if (size != null) {
             suggestionContext.setSize(size);

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/CustomHighlighter.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/CustomHighlighter.java
@@ -19,11 +19,7 @@
 package org.elasticsearch.search.fetch.subphase.highlight;
 
 import org.elasticsearch.common.text.Text;
-import org.elasticsearch.index.mapper.FieldMapper;
-import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
-import org.elasticsearch.search.fetch.subphase.highlight.Highlighter;
-import org.elasticsearch.search.fetch.subphase.highlight.HighlighterContext;
-import org.elasticsearch.search.fetch.subphase.highlight.SearchContextHighlight;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,7 +64,7 @@ public class CustomHighlighter implements Highlighter {
     }
 
     @Override
-    public boolean canHighlight(FieldMapper fieldMapper) {
+    public boolean canHighlight(MappedFieldType fieldType) {
         return true;
     }
 


### PR DESCRIPTION
Note that this a just prototype to explore a possible approach -- it is incomplete and is not meant for careful review.

Overall approach: 
- Create a new top-level `Mapper` type called `FieldAliasMapper` (so in particular, alias mappers do not inherit from `FieldMapper`).
- Make sure to keep track of aliases in `MapperService` so that when field aliases are supplied to `MapperService#fullName`, the correct concrete field type is returned. The bulk of this logic resides in `FieldTypeLookup`.

Nice properties of this approach:
- Supports alias fields when querying, sorting, aggregating, requesting suggestions, requesting `docvalue_fields`, and referencing fields in scripts. Aliases can also be used when fetching `stored_fields` (with some caveats mentioned below). Additionally, aliases can be used in the field capabilities API.
- A concrete field can be added in one mappings update, and an alias added in a separate update.
- If a concrete field type is updated, any aliases it has will always refer to the latest version.
- The complexity around resolving aliases is largely scoped to `FieldTypeLookup`.
- Consumers don't need to remember to call something like `MappedFieldType#fieldTypeForIndex` to get the underlying field type. Unfortunately it's often necessary to work with the concrete field type, as we sometimes compare against the class, or `MappedFieldType#typeName`.

Disadvantages:
- Supporting highlighting will require some work, as it's not immediately straightforward to add in this approach. The highlighter APIs expect a `FieldMapper` as opposed to a `FieldType`, so we can't just resolve the alias + pass in the concrete field type as usual. It looks like all known highlighter implementations only need the information on `FieldType`, but this is API is exposed to plugins and may be difficult to change. See `Highlighter#canHighlight` for an example of where the API expects a `FieldMapper`, when it really just needs a `MappedFieldType`.
- If an error occurs after we've already grabbed a`MappedFieldType`, we don't display the original alias name in the error message. This actually seems okay to me so far -- I think users have a general mental model of a field alias being resolved to a concrete type at some point during the request. So it's not too surprising to see an error message that references the concrete type when, for example, field types are being validated.

Current limitations (that also apply to the original approach of creating `AliasFieldType`):
- When executing a search, we must sometimes take care to refer to `MappedFieldType#name` as opposed to the field name provided originally. For an example, see the classes `SuggestionBuilder` and `FetchPhase` in either PR. This could be easy to miss when writing new code, as there's nothing in terms of type safety, etc., to stop you from using the original field name.
- Some work needs to be done around fetching `stored_fields`. First, when a field name is specified as a wildcard, alias names are not matched. In addition, when requesting `stored_fields` for an alias, the correct data comes back, but the response refers to the concrete field name: `"fields" : { "original_field" : [ "value" ]}`.
- When combining results from multiple indices, some data structures whose field names used to always line up are now no longer guaranteed to match. For example, we may now compare two `SortField` instances with different field names, since they can refer to different concrete fields depending on the index. It looks like this works out fine in the relevant cases like sorting + aggregations, but it makes me a bit nervous, as I think we're changing something that was previously an invariant.
