### PR TITLE
Replace IndexOrdinalsFieldData#getOrdinalMap with more targeted methods.

### DIFF
--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/HasChildQueryBuilder.java
@@ -34,7 +34,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.ConcreteOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedSetDVOrdinalsIndexFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
@@ -367,8 +367,8 @@ public class HasChildQueryBuilder extends AbstractQueryBuilder<HasChildQueryBuil
                 IndexSearcher indexSearcher = new IndexSearcher(reader);
                 indexSearcher.setQueryCache(null);
                 indexSearcher.setSimilarity(similarity);
-                IndexOrdinalsFieldData indexParentChildFieldData = fieldDataJoin.loadGlobal((DirectoryReader) reader);
-                OrdinalMap ordinalMap = indexParentChildFieldData.getOrdinalMap();
+                ConcreteOrdinalsFieldData indexOrdinalsFieldData = fieldDataJoin.loadGlobal((DirectoryReader) reader);
+                OrdinalMap ordinalMap = indexOrdinalsFieldData.getOrdinalMap();
                 return JoinUtil.createJoinQuery(joinField, innerQuery, toQuery, indexSearcher, scoreMode,
                     ordinalMap, minChildren, maxChildren);
             } else {

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ConcreteOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ConcreteOrdinalsFieldData.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.index.fielddata;
+
+import org.apache.lucene.index.OrdinalMap;
+
+public interface ConcreteOrdinalsFieldData extends IndexOrdinalsFieldData {
+
+    /**
+     * Returns the underlying {@link OrdinalMap} for this fielddata
+     * or null if global ordinals are not needed (constant value or single segment).
+     */
+    OrdinalMap getOrdinalMap();
+
+}

--- a/server/src/main/java/org/elasticsearch/index/fielddata/IndexOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/IndexOrdinalsFieldData.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.fielddata;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.OrdinalMap;
+import org.apache.lucene.util.LongValues;
 
 
 /**
@@ -43,8 +44,14 @@ public interface IndexOrdinalsFieldData extends IndexFieldData.Global<AtomicOrdi
     IndexOrdinalsFieldData localGlobalDirect(DirectoryReader indexReader) throws Exception;
 
     /**
-     * Returns the underlying {@link OrdinalMap} for this fielddata
-     * or null if global ordinals are not needed (constant value or single segment).
+     * Returns whether this field data implementation makes use of global ordinals.
      */
-    OrdinalMap getOrdinalMap();
+    boolean hasGlobalOrds();
+
+    /**
+     * Given a segment index, loads the mapping from segment to global ordinals. This
+     * method will throw an exception if {@link #hasGlobalOrds()} returns false.
+     */
+    LongValues getGlobalOrds(int segmentIndex);
+
 }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsBuilder.java
@@ -50,9 +50,12 @@ public enum GlobalOrdinalsBuilder {
     /**
      * Build global ordinals for the provided {@link IndexReader}.
      */
-    public static IndexOrdinalsFieldData build(final IndexReader indexReader, IndexOrdinalsFieldData indexFieldData,
-            IndexSettings indexSettings, CircuitBreakerService breakerService, Logger logger,
-            Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction) throws IOException {
+    public static GlobalOrdinalsIndexFieldData build(final IndexReader indexReader,
+                                                     IndexOrdinalsFieldData indexFieldData,
+                                                     IndexSettings indexSettings,
+                                                     CircuitBreakerService breakerService,
+                                                     Logger logger,
+                                                     Function<SortedSetDocValues, ScriptDocValues<?>> scriptFunction) throws IOException {
         assert indexReader.leaves().size() > 1;
         long startTimeNS = System.nanoTime();
 
@@ -79,8 +82,9 @@ public enum GlobalOrdinalsBuilder {
         );
     }
 
-    public static IndexOrdinalsFieldData buildEmpty(IndexSettings indexSettings, final IndexReader indexReader,
-            IndexOrdinalsFieldData indexFieldData) throws IOException {
+    public static GlobalOrdinalsIndexFieldData buildEmpty(IndexSettings indexSettings,
+                                                          final IndexReader indexReader,
+                                                          IndexOrdinalsFieldData indexFieldData) throws IOException {
         assert indexReader.leaves().size() > 1;
 
         final AtomicOrdinalsFieldData[] atomicFD = new AtomicOrdinalsFieldData[indexReader.leaves().size()];

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/GlobalOrdinalsIndexFieldData.java
@@ -24,10 +24,12 @@ import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.LongValues;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.ConcreteOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
@@ -42,7 +44,7 @@ import java.util.function.Function;
 /**
  * {@link IndexFieldData} base class for concrete global ordinals implementations.
  */
-public class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent implements IndexOrdinalsFieldData, Accountable {
+public class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent implements ConcreteOrdinalsFieldData, Accountable {
 
     private final String fieldName;
     private final long memorySizeInBytes;
@@ -113,6 +115,15 @@ public class GlobalOrdinalsIndexFieldData extends AbstractIndexComponent impleme
     }
 
     @Override
+    public boolean hasGlobalOrds() {
+        return true;
+    }
+
+    @Override
+    public LongValues getGlobalOrds(int segmentIndex) {
+        return ordinalMap.getGlobalOrds(segmentIndex);
+    }
+
     public OrdinalMap getOrdinalMap() {
         return ordinalMap;
     }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
@@ -26,6 +26,7 @@ import org.apache.lucene.index.OrdinalMap;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
@@ -54,8 +55,13 @@ public abstract class AbstractIndexOrdinalsFieldData extends AbstractIndexFieldD
     }
 
     @Override
-    public OrdinalMap getOrdinalMap() {
-        return null;
+    public boolean hasGlobalOrds() {
+        return false;
+    }
+
+    @Override
+    public LongValues getGlobalOrds(int segmentIndex) {
+        throw new IllegalArgumentException();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVOrdinalsIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedSetDVOrdinalsIndexFieldData.java
@@ -28,10 +28,12 @@ import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.SortedSetSelector;
 import org.apache.lucene.search.SortedSetSortField;
+import org.apache.lucene.util.LongValues;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.fielddata.AtomicOrdinalsFieldData;
+import org.elasticsearch.index.fielddata.ConcreteOrdinalsFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldData.XFieldComparatorSource.Nested;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
@@ -44,7 +46,7 @@ import org.elasticsearch.search.MultiValueMode;
 import java.io.IOException;
 import java.util.function.Function;
 
-public class SortedSetDVOrdinalsIndexFieldData extends DocValuesIndexFieldData implements IndexOrdinalsFieldData {
+public class SortedSetDVOrdinalsIndexFieldData extends DocValuesIndexFieldData implements ConcreteOrdinalsFieldData {
 
     private final IndexSettings indexSettings;
     private final IndexFieldDataCache cache;
@@ -91,7 +93,7 @@ public class SortedSetDVOrdinalsIndexFieldData extends DocValuesIndexFieldData i
     }
 
     @Override
-    public IndexOrdinalsFieldData loadGlobal(DirectoryReader indexReader) {
+    public ConcreteOrdinalsFieldData loadGlobal(DirectoryReader indexReader) {
         if (indexReader.leaves().size() <= 1) {
             // ordinals are already global
             return this;
@@ -128,6 +130,16 @@ public class SortedSetDVOrdinalsIndexFieldData extends DocValuesIndexFieldData i
     @Override
     public IndexOrdinalsFieldData localGlobalDirect(DirectoryReader indexReader) throws Exception {
         return GlobalOrdinalsBuilder.build(indexReader, this, indexSettings, breakerService, logger, scriptFunction);
+    }
+
+    @Override
+    public boolean hasGlobalOrds() {
+        return false;
+    }
+
+    @Override
+    public LongValues getGlobalOrds(int segmentIndex) {
+        throw new IllegalArgumentException("Sorted set field data does not use global ordinals.");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSource.java
@@ -154,14 +154,14 @@ public abstract class ValuesSource {
                 }
 
                 @Override
-                public LongUnaryOperator globalOrdinalsMapping(LeafReaderContext context) throws IOException {
+                public LongUnaryOperator globalOrdinalsMapping(LeafReaderContext context) {
                     final IndexOrdinalsFieldData global = indexFieldData.loadGlobal((DirectoryReader)context.parent.reader());
-                    final OrdinalMap map = global.getOrdinalMap();
-                    if (map == null) {
+                    if (!global.hasGlobalOrds()) {
                         // segments and global ordinals are the same
                         return LongUnaryOperator.identity();
                     }
-                    final org.apache.lucene.util.LongValues segmentToGlobalOrd = map.getGlobalOrds(context.ord);
+
+                    final org.apache.lucene.util.LongValues segmentToGlobalOrd = global.getGlobalOrds(context.ord);
                     return segmentToGlobalOrd::get;
                 }
             }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -60,6 +60,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -461,7 +462,7 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         refreshReader();
         IndexOrdinalsFieldData ifd = getForField("string", "value", hasDocValues());
         IndexOrdinalsFieldData globalOrdinals = ifd.loadGlobal(topLevelReader);
-        assertNotNull(globalOrdinals.getOrdinalMap());
+        assertTrue(globalOrdinals.hasGlobalOrds());
         assertThat(topLevelReader.leaves().size(), equalTo(3));
 
         // First segment
@@ -589,7 +590,7 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         refreshReader();
         IndexOrdinalsFieldData ifd = getForField("string", "value", hasDocValues());
         IndexOrdinalsFieldData globalOrdinals = ifd.loadGlobal(topLevelReader);
-        assertNotNull(globalOrdinals.getOrdinalMap());
+        assertTrue(globalOrdinals.hasGlobalOrds());
         assertThat(ifd.loadGlobal(topLevelReader), sameInstance(globalOrdinals));
         // 3 b/c 1 segment level caches and 1 top level cache
         // in case of doc values, we don't cache atomic FD, so only the top-level cache is there


### PR DESCRIPTION
This commit stops exposing `OrdinalMap` in favor of a more tightly scoped method
to retrieve global ordinals. It also introduces a new interface
`ConcreteOrdinalsFieldData` so that `HasChildQueryBuilder` is able to get
ahold of the concrete `OrdinalMap`.