### PR TITLE
Add microbenchmarks for vector functions.

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctionBenchmark.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 @SuppressWarnings("unused") //invoked by benchmarking framework
 public class VectorFunctionBenchmark {
-    private final static int DIMS = 100;
+    private final static int DIMS = 101;
 
     @State(Scope.Thread)
     public static class VectorState {

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctionBenchmark.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.benchmark.vectors;
+
+import org.apache.lucene.util.BytesRef;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Fork(3)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@SuppressWarnings("unused") //invoked by benchmarking framework
+public class VectorFunctionBenchmark {
+    private final static int DIMS = 100;
+
+    @State(Scope.Thread)
+    public static class VectorState {
+        private float[] queryVector;
+        private float[] vector;
+        private BytesRef encodedVector;
+
+        @Setup
+        public void createVectors() {
+            this.queryVector = randomVector();
+            this.vector = randomVector();
+            this.encodedVector = encode(vector);
+        }
+    }
+
+    @Benchmark
+    public float[] decodeNoop(VectorState state) {
+        return VectorFunctions.decodeNoop(state.encodedVector);
+    }
+
+    @Benchmark
+    public float[] decode(VectorState state) {
+        return VectorFunctions.decode(state.encodedVector);
+    }
+
+    @Benchmark
+    public float[] decodeWithByteBuffer(VectorState state) {
+        return VectorFunctions.decodeWithByteBuffer(state.encodedVector);
+    }
+
+    @Benchmark
+    public float[] decodeWithUnrolling(VectorState state) {
+        return VectorFunctions.decodeWithUnrolling(state.encodedVector);
+    }
+
+    @Benchmark
+    public double dotProduct(VectorState state) {
+        return VectorFunctions.dotProduct(state.queryVector, state.vector);
+    }
+
+    @Benchmark
+    public double dotProductWithUnrolling(VectorState state) {
+        return VectorFunctions.dotProductWithUnrolling(state.queryVector, state.vector);
+    }
+
+    @Benchmark
+    public double decodeThenDotProduct(VectorState state) {
+        return VectorFunctions.decodeThenDotProduct(state.queryVector, state.encodedVector);
+    }
+
+    @Benchmark
+    public double decodeAndDotProduct(VectorState state) {
+        return VectorFunctions.decodeAndDotProduct(state.queryVector, state.encodedVector);
+    }
+
+    @Benchmark
+    @Warmup(iterations = 0)
+    @Measurement(iterations = 1)
+    public void testVectorFunctions(VectorState state) {
+        float[] queryVector = state.queryVector;
+        float[] vector = state.vector;
+        BytesRef encodedVector = state.encodedVector;
+
+        assertEquals(vector, VectorFunctions.decode(encodedVector));
+        assertEquals(vector, VectorFunctions.decodeWithByteBuffer(encodedVector));
+        assertEquals(vector, VectorFunctions.decodeWithUnrolling(encodedVector));
+
+        float dotProduct = VectorFunctions.dotProduct(queryVector, vector);
+        assertEquals(dotProduct, VectorFunctions.dotProductWithUnrolling(queryVector, vector));
+        assertEquals(dotProduct, VectorFunctions.decodeThenDotProduct(queryVector, encodedVector));
+        assertEquals(dotProduct, VectorFunctions.decodeAndDotProduct(queryVector, encodedVector));
+    }
+
+    private void assertEquals(float a, float b) {
+        if (Math.abs(a - b) > 0.0001f) {
+            throw new RuntimeException();
+        }
+    }
+
+    private void assertEquals(float[] a, float[] b) {
+        if (a.length != b.length) {
+            throw new RuntimeException();
+        }
+        for (int i = 0; i < a.length; i++) {
+            assertEquals(a[i], b[i]);
+        }
+    }
+
+    private static float[] randomVector() {
+        Random random = new Random();
+        float[] result = new float[DIMS];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = random.nextFloat();
+        }
+        return result;
+    }
+
+    public static BytesRef encode(float[] values) {
+        final short INT_BYTES = VectorFunctions.INT_BYTES;
+        byte[] buf = new byte[INT_BYTES * values.length];
+        int offset = 0;
+        int intValue;
+        for (float value: values) {
+            intValue = Float.floatToIntBits(value);
+            buf[offset++] =  (byte) (intValue >> 24);
+            buf[offset++] = (byte) (intValue >> 16);
+            buf[offset++] = (byte) (intValue >>  8);
+            buf[offset++] = (byte) intValue;
+        }
+        return new BytesRef(buf, 0, offset);
+    }
+
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctionBenchmark.java
@@ -78,27 +78,27 @@ public class VectorFunctionBenchmark {
     }
 
     @Benchmark
-    public double dotProduct(VectorState state) {
+    public float dotProduct(VectorState state) {
         return VectorFunctions.dotProduct(state.queryVector, state.vector);
     }
 
     @Benchmark
-    public double dotProductWithUnrolling(VectorState state) {
+    public float dotProductWithUnrolling(VectorState state) {
         return VectorFunctions.dotProductWithUnrolling(state.queryVector, state.vector);
     }
 
     @Benchmark
-    public double decodeThenDotProduct(VectorState state) {
+    public float decodeThenDotProduct(VectorState state) {
         return VectorFunctions.decodeThenDotProduct(state.queryVector, state.encodedVector);
     }
 
     @Benchmark
-    public double decodeAndDotProduct(VectorState state) {
+    public float decodeAndDotProduct(VectorState state) {
         return VectorFunctions.decodeAndDotProduct(state.queryVector, state.encodedVector);
     }
 
     @Benchmark
-    public double decodeAndDotProductWithUnrolling(VectorState state) {
+    public float decodeAndDotProductWithUnrolling(VectorState state) {
         return VectorFunctions.decodeAndDotProductWithUnrolling(state.queryVector, state.encodedVector);
     }
 

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctionBenchmark.java
@@ -98,6 +98,11 @@ public class VectorFunctionBenchmark {
     }
 
     @Benchmark
+    public double decodeAndDotProductWithUnrolling(VectorState state) {
+        return VectorFunctions.decodeAndDotProductWithUnrolling(state.queryVector, state.encodedVector);
+    }
+
+    @Benchmark
     @Warmup(iterations = 0)
     @Measurement(iterations = 1)
     public void testVectorFunctions(VectorState state) {
@@ -113,6 +118,7 @@ public class VectorFunctionBenchmark {
         assertEquals(dotProduct, VectorFunctions.dotProductWithUnrolling(queryVector, vector));
         assertEquals(dotProduct, VectorFunctions.decodeThenDotProduct(queryVector, encodedVector));
         assertEquals(dotProduct, VectorFunctions.decodeAndDotProduct(queryVector, encodedVector));
+        assertEquals(dotProduct, VectorFunctions.decodeAndDotProductWithUnrolling(queryVector, encodedVector));
     }
 
     private void assertEquals(float a, float b) {

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctionBenchmark.java
@@ -73,8 +73,8 @@ public class VectorFunctionBenchmark {
     }
 
     @Benchmark
-    public float[] decodeWithUnrolling(VectorState state) {
-        return VectorFunctions.decodeWithUnrolling(state.encodedVector);
+    public float[] decodeWithUnrolling4(VectorState state) {
+        return VectorFunctions.decodeWithUnrolling4(state.encodedVector);
     }
 
     @Benchmark
@@ -83,8 +83,8 @@ public class VectorFunctionBenchmark {
     }
 
     @Benchmark
-    public float dotProductWithUnrolling(VectorState state) {
-        return VectorFunctions.dotProductWithUnrolling(state.queryVector, state.vector);
+    public float dotProductWithUnrolling4(VectorState state) {
+        return VectorFunctions.dotProductWithUnrolling4(state.queryVector, state.vector);
     }
 
     @Benchmark
@@ -98,8 +98,13 @@ public class VectorFunctionBenchmark {
     }
 
     @Benchmark
-    public float decodeAndDotProductWithUnrolling(VectorState state) {
-        return VectorFunctions.decodeAndDotProductWithUnrolling(state.queryVector, state.encodedVector);
+    public float decodeAndDotProductWithUnrolling2(VectorState state) {
+        return VectorFunctions.decodeAndDotProductWithUnrolling2(state.queryVector, state.encodedVector);
+    }
+
+    @Benchmark
+    public float decodeAndDotProductWithUnrolling4(VectorState state) {
+        return VectorFunctions.decodeAndDotProductWithUnrolling4(state.queryVector, state.encodedVector);
     }
 
     @Benchmark
@@ -112,13 +117,14 @@ public class VectorFunctionBenchmark {
 
         assertEquals(vector, VectorFunctions.decode(encodedVector));
         assertEquals(vector, VectorFunctions.decodeWithByteBuffer(encodedVector));
-        assertEquals(vector, VectorFunctions.decodeWithUnrolling(encodedVector));
+        assertEquals(vector, VectorFunctions.decodeWithUnrolling4(encodedVector));
 
         float dotProduct = VectorFunctions.dotProduct(queryVector, vector);
-        assertEquals(dotProduct, VectorFunctions.dotProductWithUnrolling(queryVector, vector));
+        assertEquals(dotProduct, VectorFunctions.dotProductWithUnrolling4(queryVector, vector));
         assertEquals(dotProduct, VectorFunctions.decodeThenDotProduct(queryVector, encodedVector));
         assertEquals(dotProduct, VectorFunctions.decodeAndDotProduct(queryVector, encodedVector));
-        assertEquals(dotProduct, VectorFunctions.decodeAndDotProductWithUnrolling(queryVector, encodedVector));
+        assertEquals(dotProduct, VectorFunctions.decodeAndDotProductWithUnrolling2(queryVector, encodedVector));
+        assertEquals(dotProduct, VectorFunctions.decodeAndDotProductWithUnrolling4(queryVector, encodedVector));
     }
 
     private void assertEquals(float a, float b) {

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctions.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctions.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+
+package org.elasticsearch.benchmark.vectors;
+
+import org.apache.lucene.util.BytesRef;
+
+import java.nio.ByteBuffer;
+
+final class VectorFunctions {
+    static final byte INT_BYTES = 4;
+
+    private VectorFunctions() {}
+
+    static float[] decodeNoop(BytesRef vectorBR) {
+        if (vectorBR == null) {
+            throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
+        }
+        int dimCount = vectorBR.length / INT_BYTES;
+        float[] vector = new float[dimCount];
+        for (int dim = 0; dim < dimCount; dim++) {
+            vector[dim] = 0.0f;
+        }
+        return vector;
+    }
+
+    static float[] decode(BytesRef vectorBR) {
+        if (vectorBR == null) {
+            throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
+        }
+        int dimCount = vectorBR.length / INT_BYTES;
+        float[] vector = new float[dimCount];
+        int offset = vectorBR.offset;
+        for (int dim = 0; dim < dimCount; dim++) {
+            int intValue = ((vectorBR.bytes[offset++] & 0xFF) << 24)   |
+                ((vectorBR.bytes[offset++] & 0xFF) << 16) |
+                ((vectorBR.bytes[offset++] & 0xFF) <<  8) |
+                (vectorBR.bytes[offset++] & 0xFF);
+            vector[dim] = Float.intBitsToFloat(intValue);
+        }
+        return vector;
+    }
+
+    static float[] decodeWithByteBuffer(BytesRef vectorBR) {
+        if (vectorBR == null) {
+            throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
+        }
+        int dimCount = vectorBR.length / INT_BYTES;
+        float[] vector = new float[dimCount];
+        ByteBuffer byteBuffer = ByteBuffer.wrap(vectorBR.bytes, vectorBR.offset, vectorBR.length);
+        for (int dim = 0; dim < dimCount; dim++) {
+            vector[dim] = byteBuffer.getFloat();
+        }
+        return vector;
+    }
+
+    static float[] decodeWithUnrolling(BytesRef vectorBR) {
+        if (vectorBR == null) {
+            throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
+        }
+        int dimCount = vectorBR.length / INT_BYTES;
+        float[] vector = new float[dimCount];
+        int offset = vectorBR.offset;
+        for (int dim = 0; dim < dimCount; dim++) {
+            int value1 = (vectorBR.bytes[offset] & 0xFF) << 24;
+            int value2 = (vectorBR.bytes[offset + 1] & 0xFF) << 16;
+            int value3 = (vectorBR.bytes[offset + 2] & 0xFF) << 8;
+            int value4 = (vectorBR.bytes[offset + 3] & 0xFF);
+
+            vector[dim] = Float.intBitsToFloat(value1 | value2 | value3 | value4);
+            offset += 4;
+        }
+        return vector;
+    }
+
+    static float dotProduct(float[] v1, float[] v2){
+        float dotProduct = 0;
+        for (int dim = 0; dim < v2.length; dim++) {
+            dotProduct += v1[dim] * v2[dim];
+        }
+        return dotProduct;
+    }
+
+    static float dotProductWithUnrolling(float[] v1, float[] v2){
+        float dot0 = 0;
+        float dot1 = 0;
+        float dot2 = 0;
+        float dot3 = 0;
+
+        int length = (v1.length / 4) * 4;
+        for (int dim = 0; dim < length; dim += 4) {
+            dot0 += v1[dim] * v2[dim];
+            dot1 += v1[dim + 1] * v2[dim + 1];
+            dot2 += v1[dim + 2] * v2[dim + 2];
+            dot3 += v1[dim + 3] * v2[dim + 3];
+        }
+
+        for (int dim = length; dim < v1.length; dim++) {
+            dot0 += v1[dim] + v2[dim];
+        }
+
+        return dot0 + dot1 + dot2 + dot3;
+    }
+
+    static float decodeThenDotProduct(float[] queryVector, BytesRef vectorBR) {
+        if (vectorBR == null) {
+            throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
+        }
+        int dimCount = vectorBR.length / INT_BYTES;
+        float[] vector = new float[dimCount];
+        int offset = vectorBR.offset;
+        for (int dim = 0; dim < dimCount; dim++) {
+            int intValue = ((vectorBR.bytes[offset++] & 0xFF) << 24)   |
+                ((vectorBR.bytes[offset++] & 0xFF) << 16) |
+                ((vectorBR.bytes[offset++] & 0xFF) <<  8) |
+                (vectorBR.bytes[offset++] & 0xFF);
+            vector[dim] = Float.intBitsToFloat(intValue);
+        }
+
+        float dotProduct = 0.0f;
+        for (int dim = 0; dim < queryVector.length; dim++) {
+            dotProduct += queryVector[dim] * vector[dim];
+        }
+        return dotProduct;
+    }
+
+    static float decodeAndDotProduct(float[] queryVector, BytesRef vectorBR) {
+        if (vectorBR == null) {
+            throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
+        }
+        int dimCount = vectorBR.length / INT_BYTES;
+        float dotProduct = 0.0f;
+        int offset = vectorBR.offset;
+        for (int dim = 0; dim < dimCount; dim++) {
+            int intValue = ((vectorBR.bytes[offset++] & 0xFF) << 24)   |
+                ((vectorBR.bytes[offset++] & 0xFF) << 16) |
+                ((vectorBR.bytes[offset++] & 0xFF) <<  8) |
+                (vectorBR.bytes[offset++] & 0xFF);
+            dotProduct += queryVector[dim] * Float.intBitsToFloat(intValue);
+        }
+        return dotProduct;
+    }
+}

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctions.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctions.java
@@ -112,13 +112,10 @@ final class VectorFunctions {
         }
         int dimCount = vectorBR.length / INT_BYTES;
         float[] vector = new float[dimCount];
-        int offset = vectorBR.offset;
+
+        ByteBuffer byteBuffer = ByteBuffer.wrap(vectorBR.bytes, vectorBR.offset, vectorBR.length);
         for (int dim = 0; dim < dimCount; dim++) {
-            int intValue = ((vectorBR.bytes[offset++] & 0xFF) << 24)   |
-                ((vectorBR.bytes[offset++] & 0xFF) << 16) |
-                ((vectorBR.bytes[offset++] & 0xFF) <<  8) |
-                (vectorBR.bytes[offset++] & 0xFF);
-            vector[dim] = Float.intBitsToFloat(intValue);
+            vector[dim] = byteBuffer.getFloat();
         }
 
         float dotProduct = 0.0f;
@@ -132,15 +129,12 @@ final class VectorFunctions {
         if (vectorBR == null) {
             throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
         }
-        int dimCount = vectorBR.length / INT_BYTES;
+
+        ByteBuffer byteBuffer = ByteBuffer.wrap(vectorBR.bytes, vectorBR.offset, vectorBR.length);
         float dotProduct = 0.0f;
-        int offset = vectorBR.offset;
-        for (int dim = 0; dim < dimCount; dim++) {
-            int intValue = ((vectorBR.bytes[offset++] & 0xFF) << 24)   |
-                ((vectorBR.bytes[offset++] & 0xFF) << 16) |
-                ((vectorBR.bytes[offset++] & 0xFF) <<  8) |
-                (vectorBR.bytes[offset++] & 0xFF);
-            dotProduct += queryVector[dim] * Float.intBitsToFloat(intValue);
+
+        for (float value : queryVector) {
+            dotProduct += value * byteBuffer.getFloat();
         }
         return dotProduct;
     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctions.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctions.java
@@ -100,7 +100,7 @@ final class VectorFunctions {
         }
 
         for (int dim = length; dim < v1.length; dim++) {
-            dot0 += v1[dim] + v2[dim];
+            dot0 += v1[dim] * v2[dim];
         }
 
         return dot0 + dot1 + dot2 + dot3;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctions.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctions.java
@@ -58,7 +58,7 @@ final class VectorFunctions {
         return vector;
     }
 
-    static float[] decodeWithUnrolling(BytesRef vectorBR) {
+    static float[] decodeWithUnrolling4(BytesRef vectorBR) {
         if (vectorBR == null) {
             throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
         }
@@ -85,7 +85,7 @@ final class VectorFunctions {
         return dotProduct;
     }
 
-    static float dotProductWithUnrolling(float[] v1, float[] v2) {
+    static float dotProductWithUnrolling4(float[] v1, float[] v2) {
         float dot0 = 0;
         float dot1 = 0;
         float dot2 = 0;
@@ -139,7 +139,7 @@ final class VectorFunctions {
         return dotProduct;
     }
 
-    static float decodeAndDotProductWithUnrolling(float[] queryVector, BytesRef vectorBR) {
+    static float decodeAndDotProductWithUnrolling2(float[] queryVector, BytesRef vectorBR) {
         if (vectorBR == null) {
             throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
         }
@@ -160,5 +160,32 @@ final class VectorFunctions {
             dot0 += byteBuffer.getFloat(offset) * queryVector[dim];
         }
         return dot0 + dot1;
+    }
+
+    static float decodeAndDotProductWithUnrolling4(float[] queryVector, BytesRef vectorBR) {
+        if (vectorBR == null) {
+            throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
+        }
+
+        float dot0 = 0;
+        float dot1 = 0;
+        float dot2 = 0;
+        float dot3 = 0;
+
+        ByteBuffer byteBuffer = ByteBuffer.wrap(vectorBR.bytes, vectorBR.offset, vectorBR.length);
+        int offset = vectorBR.offset;
+        int length = (queryVector.length / 4) * 4;
+
+        for (int dim = 0; dim < length; dim += 4, offset += 16) {
+            dot0 += byteBuffer.getFloat(offset) * queryVector[dim];
+            dot1 += byteBuffer.getFloat(offset + 4) * queryVector[dim + 1];
+            dot2 += byteBuffer.getFloat(offset + 8) * queryVector[dim + 2];
+            dot3 += byteBuffer.getFloat(offset + 12) * queryVector[dim + 3];
+        }
+
+        for (int dim = length; dim < queryVector.length; dim++, offset += 4) {
+            dot0 += byteBuffer.getFloat(offset) * queryVector[dim];
+        }
+        return dot0 + dot1 + dot2 + dot3;
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctions.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/vectors/VectorFunctions.java
@@ -85,7 +85,7 @@ final class VectorFunctions {
         return dotProduct;
     }
 
-    static float dotProductWithUnrolling(float[] v1, float[] v2){
+    static float dotProductWithUnrolling(float[] v1, float[] v2) {
         float dot0 = 0;
         float dot1 = 0;
         float dot2 = 0;
@@ -137,5 +137,28 @@ final class VectorFunctions {
             dotProduct += value * byteBuffer.getFloat();
         }
         return dotProduct;
+    }
+
+    static float decodeAndDotProductWithUnrolling(float[] queryVector, BytesRef vectorBR) {
+        if (vectorBR == null) {
+            throw new IllegalArgumentException("A document doesn't have a value for a vector field!");
+        }
+
+        float dot0 = 0;
+        float dot1 = 0;
+
+        ByteBuffer byteBuffer = ByteBuffer.wrap(vectorBR.bytes, vectorBR.offset, vectorBR.length);
+        int offset = vectorBR.offset;
+        int length = (queryVector.length / 2) * 2;
+
+        for (int dim = 0; dim < length; dim += 2, offset += 8) {
+            dot0 += byteBuffer.getFloat(offset) * queryVector[dim];
+            dot1 += byteBuffer.getFloat(offset + 4) * queryVector[dim + 1];
+        }
+
+        for (int dim = length; dim < queryVector.length; dim++, offset += 4) {
+            dot0 += byteBuffer.getFloat(offset) * queryVector[dim];
+        }
+        return dot0 + dot1;
     }
 }


### PR DESCRIPTION
This PR shows some microbenchmarks for the decoding vectors and taking the dot product of two vectors. These benchmarks are meant for local testing purposes and will not be merged into the elasticsearch repo.

```
Benchmark                                                  Mode  Cnt     Score     Error  Units
VectorFunctionBenchmark.decodeNoop                         avgt   30    31.820 ±   0.141  ns/op
VectorFunctionBenchmark.decode                             avgt   30   109.387 ±   0.179  ns/op
VectorFunctionBenchmark.decodeWithByteBuffer               avgt   30    74.400 ±   0.139  ns/op
VectorFunctionBenchmark.decodeWithUnrolling4               avgt   30   109.110 ±   0.150  ns/op
VectorFunctionBenchmark.dotProduct                         avgt   30    68.549 ±   0.737  ns/op
VectorFunctionBenchmark.dotProductWithUnrolling4           avgt   30    36.346 ±   0.030  ns/op
VectorFunctionBenchmark.decodeThenDotProduct               avgt   30   169.888 ±   0.274  ns/op
VectorFunctionBenchmark.decodeAndDotProduct                avgt   30   102.490 ±   0.135  ns/op
VectorFunctionBenchmark.decodeAndDotProductWithUnrolling2  avgt   30    92.387 ±   0.125  ns/op
VectorFunctionBenchmark.decodeAndDotProductWithUnrolling4  avgt   30   102.078 ±   0.281  ns/op
```

The results suggest a few directions to pursue, that I'll explore next in search macrobenchmarks:
- Switching to `ByteBuffer` instead of manual shifts might help for decoding.
- If a computation only requires one dot product, then decoding and performing the dot product at the same time could help.
- In `dotProductWithUnrolling4`, we manually unroll the dot product loop to clarify there are no dependencies between operations. This likely encourages SIMD to kick in, resulting in an improvement.

Platform information:
- openjdk 12.0.1 2019-04-16
- Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz