### PR TITLE
Add a dedicated vector_score query.

### DIFF
--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/Vectors.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/Vectors.java
@@ -13,11 +13,13 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.vectors.mapper.SparseVectorFieldMapper;
+import org.elasticsearch.xpack.vectors.query.VectorScoreQueryBuilder;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,9 +27,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 
-public class Vectors extends Plugin implements MapperPlugin, ActionPlugin {
+public class Vectors extends Plugin implements MapperPlugin, ActionPlugin, SearchPlugin {
 
     protected final boolean enabled;
 
@@ -51,5 +55,15 @@ public class Vectors extends Plugin implements MapperPlugin, ActionPlugin {
         mappers.put(DenseVectorFieldMapper.CONTENT_TYPE, new DenseVectorFieldMapper.TypeParser());
         mappers.put(SparseVectorFieldMapper.CONTENT_TYPE, new SparseVectorFieldMapper.TypeParser());
         return Collections.unmodifiableMap(mappers);
+    }
+
+    @Override
+    public List<QuerySpec<?>> getQueries() {
+        if (enabled == false) {
+            return emptyList();
+        }
+        return singletonList(new QuerySpec<>(VectorScoreQueryBuilder.NAME,
+            VectorScoreQueryBuilder::new,
+            VectorScoreQueryBuilder::fromXContent));
     }
 }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorScoreQuery.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorScoreQuery.java
@@ -1,0 +1,197 @@
+package org.elasticsearch.xpack.vectors.query;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.xpack.vectors.mapper.VectorEncoderDecoder;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+public class VectorScoreQuery extends Query {
+    public enum Metric {COSINE, L2 }
+
+    private final String field;
+    private final Metric metric;
+    private final float[] queryVector;
+
+    VectorScoreQuery(String field, Metric metric, float[] queryVector) {
+        this.field = field;
+        this.metric = metric;
+
+        this.queryVector = queryVector;
+        if (metric == Metric.COSINE) {
+            double queryNorm = Math.sqrt(dotProduct(queryVector, queryVector));
+            for (int i = 0; i < queryVector.length; i++) {
+                this.queryVector[i] /= queryNorm;
+            }
+        }
+    }
+
+    @Override
+    public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+        return new Weight(this) {
+            @Override
+            public void extractTerms(Set<Term> terms) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Explanation explain(LeafReaderContext context, int doc) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Scorer scorer(LeafReaderContext context) throws IOException {
+                if (metric == Metric.COSINE) {
+                    return new CosineScorer(this, field, queryVector, context);
+                } else if (metric == Metric.L2) {
+                    return new L2Scorer(this, field, queryVector, context);
+                } else {
+                    throw new UnsupportedOperationException();
+                }
+            }
+
+            @Override
+            public boolean isCacheable(LeafReaderContext ctx) {
+                return false;
+            }
+        };
+    }
+
+    private static class CosineScorer extends Scorer {
+        private final float[] queryVector;
+        private final BinaryDocValues docValues;
+
+        CosineScorer(Weight weight,
+                     String field,
+                     float[] queryVector,
+                     LeafReaderContext context) throws IOException {
+            super(weight);
+            this.queryVector = queryVector;
+            this.docValues = context.reader().getBinaryDocValues(field);
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+            return docValues;
+        }
+
+        @Override
+        public float getMaxScore(int upTo) {
+            return Float.MAX_VALUE;
+        }
+
+        @Override
+        public float score() throws IOException {
+            BytesRef vector = docValues.binaryValue();
+            ByteBuffer byteBuffer = ByteBuffer.wrap(vector.bytes, vector.offset, vector.length);
+
+            double dotProduct = 0.0;
+            for (float queryValue : queryVector) {
+                dotProduct += queryValue * byteBuffer.getFloat();
+            }
+            double docNorm = VectorEncoderDecoder.decodeVectorMagnitude(Version.CURRENT, vector);
+
+            return (float) (dotProduct / docNorm + 1.0);
+        }
+
+        @Override
+        public int docID() {
+            return docValues.docID();
+        }
+    }
+
+    private class L2Scorer extends Scorer {
+        private final float[] queryVector;
+        private final BinaryDocValues docValues;
+
+        L2Scorer(Weight weight,
+                 String field,
+                 float[] queryVector,
+                 LeafReaderContext context) throws IOException {
+            super(weight);
+            this.queryVector = queryVector;
+            this.docValues = context.reader().getBinaryDocValues(field);
+        }
+
+        @Override
+        public DocIdSetIterator iterator() {
+            return docValues;
+        }
+
+        @Override
+        public float getMaxScore(int upTo) {
+            return Float.MAX_VALUE;
+        }
+
+        @Override
+        public float score() throws IOException {
+            BytesRef vector = docValues.binaryValue();
+            ByteBuffer byteBuffer = ByteBuffer.wrap(vector.bytes, vector.offset, vector.length);
+
+            double result = 0;
+            for (float queryValue : queryVector) {
+                float diff = queryValue - byteBuffer.getFloat();
+                result += diff * diff;
+            }
+
+            return (float) (1.0 / (1.0 + Math.sqrt(result)));
+        }
+
+        @Override
+        public int docID() {
+            return docValues.docID();
+        }
+    }
+
+    private static double dotProduct(float[] a, float[] b){
+        double result = 0;
+        for (int dim = 0; dim < a.length; dim++) {
+            result += a[dim] * b[dim];
+        }
+        return result;
+    }
+
+
+    @Override
+    public String toString(String field) {
+        return new StringBuilder()
+            .append("VectorScoreQuery(field=")
+            .append(field)
+            .append(", metric=")
+            .append(metric)
+            .append(", queryVector=")
+            .append(Arrays.toString(queryVector))
+            .append(")")
+            .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VectorScoreQuery that = (VectorScoreQuery) o;
+        return Objects.equals(field, that.field) &&
+            Arrays.equals(queryVector, that.queryVector);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(field);
+        result = 31 * result + Arrays.hashCode(queryVector);
+        return result;
+    }
+}

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorScoreQueryBuilder.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorScoreQueryBuilder.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.vectors.query;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.xpack.vectors.query.VectorScoreQuery.Metric;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+
+/**
+ * A query that finds approximate nearest neighbours based on LSH hashes
+ */
+public class VectorScoreQueryBuilder extends AbstractQueryBuilder<VectorScoreQueryBuilder> {
+
+    public static final String NAME = "vector_score";
+    private static final ParseField FIELD_FIELD = new ParseField("field");
+    private static final ParseField METRIC_FIELD = new ParseField("metric");
+    private static final ParseField QUERY_VECTOR_FIELD = new ParseField("query_vector");
+
+    private static ConstructingObjectParser<VectorScoreQueryBuilder, Void> PARSER = new ConstructingObjectParser<>(NAME, false,
+        args -> {
+            Metric metric = Metric.valueOf((String) args[1]);
+
+            @SuppressWarnings("unchecked")
+            List<Float> qvList = (List<Float>) args[2];
+            float[] qv = new float[qvList.size()];
+            int i = 0;
+            for (Float f : qvList) {
+                qv[i++] = f;
+            };
+            return new VectorScoreQueryBuilder((String) args[0], metric, qv);
+        });
+
+    static {
+        PARSER.declareString(constructorArg(), FIELD_FIELD);
+        PARSER.declareString(constructorArg(), METRIC_FIELD);
+        PARSER.declareFloatArray(constructorArg(), QUERY_VECTOR_FIELD);
+    }
+
+    public static VectorScoreQueryBuilder fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    private final String field;
+    private final Metric metric;
+    private final float[] queryVector;
+
+    public VectorScoreQueryBuilder(String field, Metric metric, float[] queryVector) {
+        this.field = field;
+        this.metric = metric;
+        this.queryVector = queryVector;
+    }
+
+    public VectorScoreQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        field = in.readString();
+        metric = in.readEnum(Metric.class);
+        queryVector = in.readFloatArray();
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(field);
+        out.writeEnum(metric);
+        out.writeFloatArray(queryVector);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.field(FIELD_FIELD.getPreferredName(), field);
+        builder.field(QUERY_VECTOR_FIELD.getPreferredName(), queryVector);
+        printBoostAndQueryName(builder);
+        builder.endObject();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    protected boolean doEquals(VectorScoreQueryBuilder other) {
+        return this.field.equals(other.field) &&
+            this.metric.equals(other.metric) &&
+            Arrays.equals(this.queryVector, other.queryVector);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(this.field, this.metric, this.queryVector);
+    }
+
+    @Override
+    protected Query doToQuery(QueryShardContext context) {
+        return new VectorScoreQuery(field, metric, queryVector);
+    }
+}


### PR DESCRIPTION
This example query computes the vector functions directly on doc values to help quantify the overhead of using `script_score`. Results on glove-100-angular:

```
Algorithm                            Recall    QPS
EsBruteforce()                       1.000     5.390
EsBruteforce(vector_score_query)     1.000     6.635
```