### PR TITLE
Only retrieve doc values once in vector functions.

### DIFF
--- a/x-pack/plugin/vectors/src/main/resources/org/elasticsearch/xpack/vectors/query/whitelist.txt
+++ b/x-pack/plugin/vectors/src/main/resources/org/elasticsearch/xpack/vectors/query/whitelist.txt
@@ -14,8 +14,8 @@ class org.elasticsearch.script.ScoreScript @no_import {
 
 static_import {
     double l1norm(org.elasticsearch.script.ScoreScript, List, VectorScriptDocValues.DenseVectorScriptDocValues) bound_to org.elasticsearch.xpack.vectors.query.ScoreScriptUtils$L1Norm
-    double l2norm(org.elasticsearch.script.ScoreScript, List, VectorScriptDocValues.DenseVectorScriptDocValues) bound_to org.elasticsearch.xpack.vectors.query.ScoreScriptUtils$L2Norm
-    double cosineSimilarity(org.elasticsearch.script.ScoreScript, List, VectorScriptDocValues.DenseVectorScriptDocValues) bound_to org.elasticsearch.xpack.vectors.query.ScoreScriptUtils$CosineSimilarity
+    double l2norm(org.elasticsearch.script.ScoreScript, String, List) bound_to org.elasticsearch.xpack.vectors.query.ScoreScriptUtils$L2Norm
+    double cosineSimilarity(org.elasticsearch.script.ScoreScript, String, List) bound_to org.elasticsearch.xpack.vectors.query.ScoreScriptUtils$CosineSimilarity
     double dotProduct(org.elasticsearch.script.ScoreScript, List, VectorScriptDocValues.DenseVectorScriptDocValues) bound_to org.elasticsearch.xpack.vectors.query.ScoreScriptUtils$DotProduct
     double l1normSparse(org.elasticsearch.script.ScoreScript, Map, VectorScriptDocValues.SparseVectorScriptDocValues) bound_to org.elasticsearch.xpack.vectors.query.ScoreScriptUtils$L1NormSparse
     double l2normSparse(org.elasticsearch.script.ScoreScript, Map, VectorScriptDocValues.SparseVectorScriptDocValues) bound_to org.elasticsearch.xpack.vectors.query.ScoreScriptUtils$L2NormSparse


### PR DESCRIPTION
Another example change to gauge the effect of retrieving `ScriptDocValues` for every document. This requires a change to the signature of the script function:

```
old signature:     cosineSimilarity(query, doc['vector_field'])
new signature:     cosineSimilarity('vector_field', query)
```

It shows a small improvement in performance on glove-100-angular:

```
Algorithm                            Recall    QPS
EsBruteforce()                       1.000     5.390
EsBruteforce(cache_docvalues)        1.000     5.564
```