### PR TITLE
Add a custom vector_script engine.

### DIFF
--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/Vectors.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/Vectors.java
@@ -13,13 +13,19 @@ import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.ScriptPlugin;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.vectors.mapper.DenseVectorFieldMapper;
 import org.elasticsearch.xpack.vectors.mapper.SparseVectorFieldMapper;
+import org.elasticsearch.xpack.vectors.query.VectorScriptEngine;
+
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,7 +33,7 @@ import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 
-public class Vectors extends Plugin implements MapperPlugin, ActionPlugin {
+public class Vectors extends Plugin implements MapperPlugin, ActionPlugin, ScriptPlugin {
 
     protected final boolean enabled;
 
@@ -51,5 +57,10 @@ public class Vectors extends Plugin implements MapperPlugin, ActionPlugin {
         mappers.put(DenseVectorFieldMapper.CONTENT_TYPE, new DenseVectorFieldMapper.TypeParser());
         mappers.put(SparseVectorFieldMapper.CONTENT_TYPE, new SparseVectorFieldMapper.TypeParser());
         return Collections.unmodifiableMap(mappers);
+    }
+
+    @Override
+    public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+        return new VectorScriptEngine();
     }
 }

--- a/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorScriptEngine.java
+++ b/x-pack/plugin/vectors/src/main/java/org/elasticsearch/xpack/vectors/query/VectorScriptEngine.java
@@ -1,0 +1,100 @@
+package org.elasticsearch.xpack.vectors.query;
+
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.script.ScoreScript;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.search.lookup.LeafDocLookup;
+import org.elasticsearch.search.lookup.SearchLookup;
+import org.elasticsearch.xpack.vectors.mapper.VectorEncoderDecoder;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+public class VectorScriptEngine implements ScriptEngine {
+
+    @Override
+    public String getType() {
+        return "vector_script";
+    }
+
+    @Override
+    public <T> T compile(String scriptName, String scriptSource,
+                         ScriptContext<T> context, Map<String, String> params) {
+        if (context.equals(ScoreScript.CONTEXT) == false) {
+            throw new IllegalArgumentException(getType()
+                + " scripts cannot be used for context ["
+                + context.name + "]");
+        }
+
+        ScoreScript.Factory factory = VectorScriptFactory::new;
+        return context.factoryClazz.cast(factory);
+    }
+
+    @Override
+    public void close() {
+        // optionally close resources
+    }
+
+    private static class VectorScriptFactory implements ScoreScript.LeafFactory {
+        private final Map<String, Object> params;
+        private final SearchLookup lookup;
+
+        private final List<Number> queryVector;
+        private final String field;
+
+        @SuppressWarnings("unchecked")
+        private VectorScriptFactory(
+            Map<String, Object> params, SearchLookup lookup) {
+            if (params.containsKey("field") == false) {
+                throw new IllegalArgumentException(
+                    "Missing parameter [field]");
+            }
+            if (params.containsKey("query_vector") == false) {
+                throw new IllegalArgumentException(
+                    "Missing parameter [term]");
+            }
+            this.params = params;
+            this.lookup = lookup;
+            field = params.get("field").toString();
+
+            queryVector = (List<Number>) params.get("query_vector");
+        }
+
+        @Override
+        public boolean needs_score() {
+            return false;
+        }
+
+        @Override
+        public ScoreScript newInstance(LeafReaderContext context) {
+            ScoreScript script = new ScoreScript(params, lookup, context) {
+                @Override
+                public double execute() {
+                    return 0;
+                }
+            };
+            script._setIndexVersion(Version.CURRENT);
+
+            ScoreScriptUtils.CosineSimilarity cosine = new ScoreScriptUtils.CosineSimilarity(script, queryVector);
+            LeafDocLookup docLookup = lookup.doc().getLeafDocLookup(context);
+
+            return new ScoreScript(params, lookup, context) {
+
+                @Override
+                public void setDocument(int docId) {
+                    docLookup.setDocument(docId);
+                }
+
+                @Override
+                public double execute() {
+                    VectorScriptDocValues.DenseVectorScriptDocValues docValues = (VectorScriptDocValues.DenseVectorScriptDocValues) docLookup.get(field);
+                    return cosine.cosineSimilarity(docValues) + 1.0;
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
This helps quantify the performance difference due to scripting. Results on `random-s-100-angular`:

```
Algorithm                             Recall      QPS
EsBruteforce(baseline)                1.000       63.304
EsBruteforce(vector_query)            1.000       74.759
EsBruteforce(vector_script)           1.000       66.950
EsBruteforce(vector_script_direct)    1.000       66.245
EsBruteforce(direct_docvalues)        1.000       68.860
```

* `baseline` is the current approach to vector scoring (in elasticsearch 7.5)
* `vector_query` runs the dedicated query which avoids scripting altogether (https://github.com/jtibshirani/elasticsearch/pull/4)
* `vector_script` uses the custom script engine from this PR (commit 2212966)
* `vector_script_direct` uses the custom script engine from this PR, but computes the similarity directly instead of using `CosineSimilarity` (commit 65d73f1)
* `direct_docvalues` builds on `vector_script_direct` and accesses docvalues directly as opposed to using `LeafDocLookup` (commit ef8c261)