### PR TITLE
Sketch out how to pass a service to a FetchSubPhase.

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -899,7 +899,7 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
         // TODO: is the full inference config really needed?
         String modelId = "model-id";
         InferenceConfig config = new RegressionConfig("ignored");
-        return List.of(new InferencePhase(modelId, config, this.modelLoadingService.get()));
+        return List.of(new InferencePhase(modelId, config, this.modelLoadingService));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
@@ -20,11 +20,11 @@ import java.util.Map;
 public class InferencePhase implements FetchSubPhase {
     private final String modelId;
     private final InferenceConfig config;
-    private final ModelLoadingService modelLoadingService;
+    private final SetOnce<ModelLoadingService> modelLoadingService;
 
     public InferencePhase(String modelId,
                           InferenceConfig config,
-                          ModelLoadingService modelLoadingService) {
+                          SetOnce<ModelLoadingService> modelLoadingService) {
         this.modelId = modelId;
         this.config = config;
         this.modelLoadingService = modelLoadingService;
@@ -33,7 +33,7 @@ public class InferencePhase implements FetchSubPhase {
     @Override
     public void hitsExecute(SearchContext searchContext, SearchHit[] hits) throws IOException {
         SetOnce<Model> model = new SetOnce<>();
-        modelLoadingService.getModel(modelId, ActionListener.wrap(
+        modelLoadingService.get().getModel(modelId, ActionListener.wrap(
             model::set,
             m -> {throw new RuntimeException();}));
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferencePhase.java
@@ -1,0 +1,52 @@
+package org.elasticsearch.xpack.ml.inference.search;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.fetch.FetchSubPhase;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.ml.inference.loadingservice.Model;
+import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A very rough sketch of a fetch sub phase that performs inference on each search hit,
+ * then augments the hit with the result.
+ */
+public class InferencePhase implements FetchSubPhase {
+    private final String modelId;
+    private final InferenceConfig config;
+    private final ModelLoadingService modelLoadingService;
+
+    public InferencePhase(String modelId,
+                          InferenceConfig config,
+                          ModelLoadingService modelLoadingService) {
+        this.modelId = modelId;
+        this.config = config;
+        this.modelLoadingService = modelLoadingService;
+    }
+
+    @Override
+    public void hitsExecute(SearchContext searchContext, SearchHit[] hits) throws IOException {
+        SetOnce<Model> model = new SetOnce<>();
+        modelLoadingService.getModel(modelId, ActionListener.wrap(
+            model::set,
+            m -> {throw new RuntimeException();}));
+
+        for (SearchHit hit : hits) {
+            // TODO: get fields through context.lookup() (or from the search hit?)
+            Map<String, Object> document = Map.of();
+
+            SetOnce<InferenceResults> result = new SetOnce<>();
+            model.get().infer(document, config, ActionListener.wrap(
+                result::set,
+                m -> {throw new RuntimeException();}));
+
+            // TODO: add inference result to hit.
+        }
+    }
+}


### PR DESCRIPTION
**Note:** this PR is just meant for discussion and is not intended as a draft or prototype.

From catching up with ES infrastructure experts, the preferred way to pass a
service to a custom search component is to directly pass the service when
instantiating the component. This PR gives a simple example of how this would
be done with a new `FetchSubPhase`.