### PR TITLE
Pass in ModelLoadingService to the inference rescorer.

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -353,14 +353,12 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
     }
 
     private InferenceRescorerBuilder rescorerFromStream(StreamInput in) throws IOException {
-        InferenceRescorerBuilder result = new InferenceRescorerBuilder(in);
-        result.setModelLoadingService(modelLoadingService);
+        InferenceRescorerBuilder result = new InferenceRescorerBuilder(in, modelLoadingService);
         return result;
     }
 
     private InferenceRescorerBuilder rescorerFromXContent(XContentParser parser) {
-        InferenceRescorerBuilder result = InferenceRescorerBuilder.fromXContent(parser);
-        result.setModelLoadingService(modelLoadingService);
+        InferenceRescorerBuilder result = InferenceRescorerBuilder.fromXContent(parser, modelLoadingService);
         return result;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -47,6 +47,7 @@ import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.PersistentTaskPlugin;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
@@ -211,6 +212,7 @@ import org.elasticsearch.xpack.ml.dataframe.process.results.MemoryUsageEstimatio
 import org.elasticsearch.xpack.ml.inference.ingest.InferenceProcessor;
 import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
+import org.elasticsearch.xpack.ml.inference.search.InferenceRescorerBuilder;
 import org.elasticsearch.xpack.ml.job.JobManager;
 import org.elasticsearch.xpack.ml.job.JobManagerHolder;
 import org.elasticsearch.xpack.ml.job.UpdateJobProcessNotifier;
@@ -318,7 +320,7 @@ import java.util.function.UnaryOperator;
 
 import static java.util.Collections.emptyList;
 
-public class MachineLearning extends Plugin implements SystemIndexPlugin, AnalysisPlugin, IngestPlugin, PersistentTaskPlugin {
+public class MachineLearning extends Plugin implements SystemIndexPlugin, AnalysisPlugin, IngestPlugin, PersistentTaskPlugin, SearchPlugin {
     public static final String NAME = "ml";
     public static final String BASE_PATH = "/_ml/";
     public static final String PRE_V7_BASE_PATH = "/_xpack/ml/";
@@ -341,6 +343,12 @@ public class MachineLearning extends Plugin implements SystemIndexPlugin, Analys
         }
 
     };
+
+    @Override
+    public List<RescorerSpec<?>> getRescorers() {
+        return Collections.singletonList(
+                new RescorerSpec<>(InferenceRescorerBuilder.NAME, InferenceRescorerBuilder::new, InferenceRescorerBuilder::fromXContent));
+    }
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -8,13 +8,13 @@ package org.elasticsearch.xpack.ml.inference.loadingservice;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelDefinition;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
+import org.elasticsearch.xpack.core.ml.inference.results.ClassificationInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.core.ml.inference.results.ClassificationInferenceResults;
-import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
-import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResults;
 import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 
 import java.util.HashSet;
@@ -44,6 +44,10 @@ public class LocalModel implements Model {
         return modelId;
     }
 
+    public Set<String> getFieldNames() {
+        return fieldNames;
+    }
+
     @Override
     public String getResultsType() {
         switch (trainedModelDefinition.getTrainedModel().targetType()) {
@@ -61,14 +65,17 @@ public class LocalModel implements Model {
     @Override
     public void infer(Map<String, Object> fields, InferenceConfig config, ActionListener<InferenceResults> listener) {
         try {
-            if (fieldNames.stream().allMatch(f -> MapHelper.dig(f, fields) == null)) {
-                listener.onResponse(new WarningInferenceResults(Messages.getMessage(INFERENCE_WARNING_ALL_FIELDS_MISSING, modelId)));
-                return;
-            }
-
-            listener.onResponse(trainedModelDefinition.infer(fields, config));
+            listener.onResponse(infer(fields, config));
         } catch (Exception e) {
             listener.onFailure(e);
+        }
+    }
+
+    public InferenceResults infer(Map<String, Object> fields, InferenceConfig config) {
+        if (fieldNames.stream().allMatch(f -> MapHelper.dig(f, fields) == null)) {
+            return new WarningInferenceResults(Messages.getMessage(INFERENCE_WARNING_ALL_FIELDS_MISSING, modelId));
+        } else {
+            return trainedModelDefinition.infer(fields, config);
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/LocalModel.java
@@ -44,6 +44,7 @@ public class LocalModel implements Model {
         return modelId;
     }
 
+    @Override
     public Set<String> getFieldNames() {
         return fieldNames;
     }
@@ -71,6 +72,7 @@ public class LocalModel implements Model {
         }
     }
 
+    @Override
     public InferenceResults infer(Map<String, Object> fields, InferenceConfig config) {
         if (fieldNames.stream().allMatch(f -> MapHelper.dig(f, fields) == null)) {
             return new WarningInferenceResults(Messages.getMessage(INFERENCE_WARNING_ALL_FIELDS_MISSING, modelId));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/Model.java
@@ -10,6 +10,7 @@ import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 
 import java.util.Map;
+import java.util.Set;
 
 public interface Model {
 
@@ -17,5 +18,10 @@ public interface Model {
 
     void infer(Map<String, Object> fields, InferenceConfig inferenceConfig, ActionListener<InferenceResults> listener);
 
+    InferenceResults infer(Map<String, Object> fields, InferenceConfig config);
+
     String getModelId();
+
+    Set<String> getFieldNames();
+
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -272,11 +272,10 @@ public class TrainedModelProvider {
             listener::onFailure
         );
 
-        executeAsyncWithOrigin(client,
-            ML_ORIGIN,
+        MultiSearchResponse response = client.execute(
             MultiSearchAction.INSTANCE,
-            multiSearchRequestBuilder.request(),
-            multiSearchResponseActionListener);
+            multiSearchRequestBuilder.request()).actionGet();
+        multiSearchResponseActionListener.onResponse(response);
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferenceRescorer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferenceRescorer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.inference.search;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Explanation;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.search.rescore.RescoreContext;
+import org.elasticsearch.search.rescore.Rescorer;
+import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.SingleValueInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
+import org.elasticsearch.xpack.ml.inference.loadingservice.LocalModel;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class InferenceRescorer implements Rescorer {
+
+    private static final Logger logger = LogManager.getLogger(InferenceRescorer.class);
+
+    private final LocalModel model;
+    private final InferenceConfig inferenceConfig;
+    private final Map<String, String> fieldMap;
+    private final InferenceRescorerBuilder.ScoreModeSettings scoreModeSettings;
+
+    InferenceRescorer(
+        LocalModel model,
+        InferenceConfig inferenceConfig,
+        Map<String, String> fieldMap,
+        InferenceRescorerBuilder.ScoreModeSettings scoreModeSettings
+    ) {
+        this.model = model;
+        this.inferenceConfig = inferenceConfig;
+        this.fieldMap = fieldMap;
+        this.scoreModeSettings = scoreModeSettings;
+
+        assert inferenceConfig instanceof RegressionConfig;
+    }
+
+    @Override
+    public TopDocs rescore(TopDocs topDocs, IndexSearcher searcher, RescoreContext rescoreContext) throws IOException {
+
+        // Copy ScoreDoc[] and sort by ascending docID:
+        ScoreDoc[] sortedHits = topDocs.scoreDocs.clone();
+        Comparator<ScoreDoc> docIdComparator = Comparator.comparingInt(sd -> sd.doc);
+        Arrays.sort(sortedHits, docIdComparator);
+
+        Set<String> fieldsToRead = new HashSet<>(model.getFieldNames());
+        // field map is fieldname in doc -> fieldname expected by model
+        for (Map.Entry<String, String> entry : fieldMap.entrySet()) {
+            if (fieldsToRead.contains(entry.getValue())) {
+                // replace the model fieldname with the doc fieldname
+                fieldsToRead.remove(entry.getValue());
+                fieldsToRead.add(entry.getKey());
+            }
+        }
+
+        List<LeafReaderContext> leaves = searcher.getIndexReader().getContext().leaves();
+        Map<String, Object> fields = new HashMap<>();
+
+        int currentReader = 0;
+        int endDoc = 0;
+        LeafReaderContext readerContext = null;
+
+        for (int hitIndex = 0; hitIndex < sortedHits.length; hitIndex++) {
+            ScoreDoc hit = sortedHits[hitIndex];
+            int docId = hit.doc;
+
+            // get the context for this docId
+            while (docId >= endDoc) {
+                readerContext = leaves.get(currentReader);
+                currentReader++;
+                endDoc = readerContext.docBase + readerContext.reader().maxDoc();
+            }
+
+            for (String field : fieldsToRead) {
+                SortedNumericDocValues docValuesIter = DocValues.getSortedNumeric(readerContext.reader(), field);
+                SortedNumericDoubleValues doubles = FieldData.sortableLongBitsToDoubles(docValuesIter);
+                if (doubles.advanceExact(hit.doc)) {
+                    double val = doubles.nextValue();
+                    fields.put(fieldMap.getOrDefault(field, field), val);
+                } else if (docValuesIter.docID() == DocIdSetIterator.NO_MORE_DOCS) {
+                    logger.warn("No more docs for field {}, doc {}", field, hit.doc);
+                    fields.remove(field);
+                } else {
+                    logger.warn("no value for field {}, doc {}", field, hit.doc);
+                    fields.remove(field);
+                }
+            }
+
+            InferenceResults infer = model.infer(fields, inferenceConfig);
+            if (infer instanceof WarningInferenceResults) {
+                String message = ((WarningInferenceResults) infer).getWarning();
+                logger.warn("inference error: " + message);
+                throw new ElasticsearchException(message);
+            } else {
+                SingleValueInferenceResults regressionResult = (SingleValueInferenceResults) infer;
+
+                float combinedScore = scoreModeSettings.scoreMode.combine(
+                    hit.score * scoreModeSettings.queryWeight,
+                    regressionResult.value().floatValue() * scoreModeSettings.modelWeight
+                );
+
+                sortedHits[hitIndex] = new ScoreDoc(hit.doc, combinedScore);
+            }
+        }
+
+        return new TopDocs(topDocs.totalHits, sortedHits);
+    }
+
+    @Override
+    public Explanation explain(int topLevelDocId, IndexSearcher searcher, RescoreContext rescoreContext, Explanation sourceExplanation) {
+        return Explanation.match(1.0, "because");
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferenceRescorer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferenceRescorer.java
@@ -26,7 +26,7 @@ import org.elasticsearch.xpack.core.ml.inference.results.SingleValueInferenceRes
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
-import org.elasticsearch.xpack.ml.inference.loadingservice.LocalModel;
+import org.elasticsearch.xpack.ml.inference.loadingservice.Model;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -41,17 +41,15 @@ public class InferenceRescorer implements Rescorer {
 
     private static final Logger logger = LogManager.getLogger(InferenceRescorer.class);
 
-    private final LocalModel model;
+    private final Model model;
     private final InferenceConfig inferenceConfig;
     private final Map<String, String> fieldMap;
     private final InferenceRescorerBuilder.ScoreModeSettings scoreModeSettings;
 
-    InferenceRescorer(
-        LocalModel model,
-        InferenceConfig inferenceConfig,
-        Map<String, String> fieldMap,
-        InferenceRescorerBuilder.ScoreModeSettings scoreModeSettings
-    ) {
+    InferenceRescorer(Model model,
+                      InferenceConfig inferenceConfig,
+                      Map<String, String> fieldMap,
+                      InferenceRescorerBuilder.ScoreModeSettings scoreModeSettings) {
         this.model = model;
         this.inferenceConfig = inferenceConfig;
         this.fieldMap = fieldMap;
@@ -67,6 +65,7 @@ public class InferenceRescorer implements Rescorer {
         ScoreDoc[] sortedHits = topDocs.scoreDocs.clone();
         Comparator<ScoreDoc> docIdComparator = Comparator.comparingInt(sd -> sd.doc);
         Arrays.sort(sortedHits, docIdComparator);
+
 
         Set<String> fieldsToRead = new HashSet<>(model.getFieldNames());
         // field map is fieldname in doc -> fieldname expected by model

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferenceRescorerBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/search/InferenceRescorerBuilder.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.inference.search;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ConstructingObjectParser;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.QueryRewriteContext;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.search.rescore.QueryRescoreMode;
+import org.elasticsearch.search.rescore.RescoreContext;
+import org.elasticsearch.search.rescore.RescorerBuilder;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.ml.inference.loadingservice.LocalModel;
+import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.common.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class InferenceRescorerBuilder extends RescorerBuilder<InferenceRescorerBuilder> {
+
+    public static final String NAME = "ml_rescore";
+
+    public static final ParseField MODEL_ID = new ParseField("model_id");
+    private static final ParseField INFERENCE_CONFIG = new ParseField("inference_config");
+    private static final ParseField FIELD_MAPPINGS = new ParseField("field_mappings");
+
+    private static final ParseField QUERY_WEIGHT = new ParseField("query_weight");
+    private static final ParseField MODEL_WEIGHT = new ParseField("model_weight");
+    private static final ParseField SCORE_MODE = new ParseField("score_mode");
+
+    private static final float DEFAULT_QUERY_WEIGHT = 1.0f;
+    private static final float DEFAULT_MODEL_WEIGHT = 1.0f;
+    private static final QueryRescoreMode DEFAULT_SCORE_MODE = QueryRescoreMode.Total;
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<InferenceRescorerBuilder, Void> PARSER = new ConstructingObjectParser<>(
+        NAME,
+        args -> new InferenceRescorerBuilder((String) args[0], (List<InferenceConfig>) args[1], (Map<String, String>) args[2])
+    );
+
+    static {
+        PARSER.declareString(constructorArg(), MODEL_ID);
+        PARSER.declareNamedObjects(optionalConstructorArg(), (p, c, n) -> p.namedObject(InferenceConfig.class, n, c), INFERENCE_CONFIG);
+        PARSER.declareField(optionalConstructorArg(), (p, c) -> p.mapStrings(), FIELD_MAPPINGS, ObjectParser.ValueType.OBJECT);
+        PARSER.declareFloat(InferenceRescorerBuilder::setQueryWeight, QUERY_WEIGHT);
+        PARSER.declareFloat(InferenceRescorerBuilder::setModelWeight, MODEL_WEIGHT);
+        PARSER.declareString((builder, mode) -> builder.setScoreMode(QueryRescoreMode.fromString(mode)), SCORE_MODE);
+    }
+
+    public static InferenceRescorerBuilder fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    private final String modelId;
+    private final InferenceConfig inferenceConfig;
+    private final Map<String, String> fieldMap;
+
+    private LocalModel model;
+    private Supplier<LocalModel> modelSupplier;
+
+    private float queryWeight = DEFAULT_QUERY_WEIGHT;
+    private float modelWeight = DEFAULT_MODEL_WEIGHT;
+    private QueryRescoreMode scoreMode = DEFAULT_SCORE_MODE;
+
+    private InferenceRescorerBuilder(String modelId, @Nullable List<InferenceConfig> config, @Nullable Map<String, String> fieldMap) {
+        this.modelId = modelId;
+        if (config != null) {
+            assert config.size() == 1;
+            this.inferenceConfig = config.get(0);
+        } else {
+            this.inferenceConfig = null;
+        }
+        this.fieldMap = fieldMap;
+    }
+
+    InferenceRescorerBuilder(String modelId, @Nullable InferenceConfig config, @Nullable Map<String, String> fieldMap) {
+        this.modelId = modelId;
+        this.inferenceConfig = config;
+        this.fieldMap = fieldMap;
+    }
+
+    private InferenceRescorerBuilder(
+        String modelId,
+        @Nullable InferenceConfig config,
+        @Nullable Map<String, String> fieldMap,
+        Supplier<LocalModel> modelSupplier
+    ) {
+        this(modelId, config, fieldMap);
+        this.modelSupplier = modelSupplier;
+    }
+
+    private InferenceRescorerBuilder(
+        String modelId,
+        @Nullable InferenceConfig config,
+        @Nullable Map<String, String> fieldMap,
+        LocalModel model
+    ) {
+        this(modelId, config, fieldMap);
+        this.model = Objects.requireNonNull(model);
+    }
+
+    public InferenceRescorerBuilder(StreamInput in) throws IOException {
+        super(in);
+        modelId = in.readString();
+        inferenceConfig = in.readOptionalNamedWriteable(InferenceConfig.class);
+        boolean readMap = in.readBoolean();
+        if (readMap) {
+            fieldMap = in.readMap(StreamInput::readString, StreamInput::readString);
+        } else {
+            fieldMap = null;
+        }
+        queryWeight = in.readFloat();
+        modelWeight = in.readFloat();
+        scoreMode = QueryRescoreMode.readFromStream(in);
+    }
+
+    void setQueryWeight(float queryWeight) {
+        this.queryWeight = queryWeight;
+    }
+
+    void setModelWeight(float modelWeight) {
+        this.modelWeight = modelWeight;
+    }
+
+    void setScoreMode(QueryRescoreMode scoreMode) {
+        this.scoreMode = scoreMode;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        if (modelSupplier != null) {
+            throw new IllegalStateException("can't serialize model supplier. Missing a rewriteAndFetch?");
+        }
+
+        out.writeString(modelId);
+        out.writeOptionalNamedWriteable(inferenceConfig);
+        boolean fieldMapPresent = fieldMap != null;
+        out.writeBoolean(fieldMapPresent);
+        if (fieldMapPresent) {
+            out.writeMap(fieldMap, StreamOutput::writeString, StreamOutput::writeString);
+        }
+        out.writeFloat(queryWeight);
+        out.writeFloat(modelWeight);
+        scoreMode.writeTo(out);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(MODEL_ID.getPreferredName(), modelId);
+        if (inferenceConfig != null) {
+            builder.startObject(INFERENCE_CONFIG.getPreferredName());
+            builder.field(inferenceConfig.getName(), inferenceConfig);
+            builder.endObject();
+        }
+        if (fieldMap != null) {
+            builder.field(FIELD_MAPPINGS.getPreferredName(), fieldMap);
+        }
+        builder.field(QUERY_WEIGHT.getPreferredName(), queryWeight);
+        builder.field(MODEL_WEIGHT.getPreferredName(), modelWeight);
+        builder.field(SCORE_MODE.getPreferredName(), scoreMode.name().toLowerCase(Locale.ROOT));
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public RescorerBuilder<InferenceRescorerBuilder> rewrite(QueryRewriteContext ctx) {
+
+        assert modelId != null;
+
+        if (model != null) {
+            return this;
+        } else if (modelSupplier != null) {
+            if (modelSupplier.get() == null) {
+                return this;
+            } else {
+                return copyScoringSettings(new InferenceRescorerBuilder(modelId, inferenceConfig, fieldMap, modelSupplier.get()));
+
+            }
+        } else {
+            SetOnce<LocalModel> modelHolder = new SetOnce<>();
+
+            ctx.registerAsyncAction(((client, actionListener) -> {
+                TrainedModelProvider modelProvider = new TrainedModelProvider(client, ctx.getXContentRegistry());
+                modelProvider.getTrainedModel(modelId, true, ActionListener.wrap(trainedModel -> {
+                    LocalModel model = new LocalModel(
+                        modelId,
+                        trainedModel.ensureParsedDefinition(ctx.getXContentRegistry()).getModelDefinition(),
+                        trainedModel.getInput()
+                    );
+                    modelHolder.set(model);
+                    actionListener.onResponse(null);
+                }, actionListener::onFailure));
+            }));
+
+            return copyScoringSettings(new InferenceRescorerBuilder(modelId, inferenceConfig, fieldMap, modelHolder::get));
+        }
+    }
+
+    private InferenceRescorerBuilder copyScoringSettings(InferenceRescorerBuilder target) {
+        target.setQueryWeight(queryWeight);
+        target.setModelWeight(modelWeight);
+        target.setScoreMode(scoreMode);
+        return target;
+    }
+
+    @Override
+    protected RescoreContext innerBuildContext(int windowSize, QueryShardContext context) {
+        LocalModel m = (model != null) ? model : modelSupplier.get();
+        assert m != null;
+
+        return new RescoreContext(windowSize, new InferenceRescorer(m, inferenceConfig, fieldMap, scoreModeSettings()));
+    }
+
+    class ScoreModeSettings {
+        float queryWeight;
+        float modelWeight;
+        QueryRescoreMode scoreMode;
+
+        ScoreModeSettings(float queryWeight, float modelWeight, QueryRescoreMode scoreMode) {
+            this.queryWeight = queryWeight;
+            this.modelWeight = modelWeight;
+            this.scoreMode = scoreMode;
+        }
+    }
+
+    private ScoreModeSettings scoreModeSettings() {
+        return new ScoreModeSettings(this.queryWeight, this.modelWeight, this.scoreMode);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(windowSize, modelId, inferenceConfig, fieldMap, queryWeight, modelWeight, scoreMode);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        InferenceRescorerBuilder other = (InferenceRescorerBuilder) obj;
+        return Objects.equals(windowSize, other.windowSize)
+            && Objects.equals(modelId, other.modelId)
+            && Objects.equals(inferenceConfig, other.inferenceConfig)
+            && Objects.equals(fieldMap, other.fieldMap)
+            && Objects.equals(queryWeight, other.queryWeight)
+            && Objects.equals(modelWeight, other.modelWeight)
+            && Objects.equals(scoreMode, other.scoreMode);
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/search/InferenceRescorerBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/search/InferenceRescorerBuilderTests.java
@@ -6,6 +6,7 @@
 
 package org.elasticsearch.xpack.ml.inference.search;
 
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -24,12 +25,12 @@ public class InferenceRescorerBuilderTests extends AbstractSerializingTestCase<I
 
     @Override
     protected InferenceRescorerBuilder doParseInstance(XContentParser parser) {
-        return InferenceRescorerBuilder.fromXContent(parser);
+        return InferenceRescorerBuilder.fromXContent(parser, new SetOnce<>());
     }
 
     @Override
     protected Writeable.Reader<InferenceRescorerBuilder> instanceReader() {
-        return InferenceRescorerBuilder::new;
+        return in -> new InferenceRescorerBuilder(in, new SetOnce<>());
     }
 
     @Override
@@ -44,7 +45,7 @@ public class InferenceRescorerBuilderTests extends AbstractSerializingTestCase<I
             }
         }
 
-        InferenceRescorerBuilder builder = new InferenceRescorerBuilder(randomAlphaOfLength(8), config, randomMap());
+        InferenceRescorerBuilder builder = new InferenceRescorerBuilder(randomAlphaOfLength(8), config, randomMap(), new SetOnce<>());
         if (randomBoolean()) {
             builder.setQueryWeight((float) randomDoubleBetween(0.0, 1.0, true));
             builder.setModelWeight((float) randomDoubleBetween(0.0, 2.0, true));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/search/InferenceRescorerBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/search/InferenceRescorerBuilderTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.ml.inference.search;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.search.rescore.QueryRescoreMode;
+import org.elasticsearch.test.AbstractSerializingTestCase;
+import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigTests;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InferenceRescorerBuilderTests extends AbstractSerializingTestCase<InferenceRescorerBuilder> {
+
+    @Override
+    protected InferenceRescorerBuilder doParseInstance(XContentParser parser) {
+        return InferenceRescorerBuilder.fromXContent(parser);
+    }
+
+    @Override
+    protected Writeable.Reader<InferenceRescorerBuilder> instanceReader() {
+        return InferenceRescorerBuilder::new;
+    }
+
+    @Override
+    protected InferenceRescorerBuilder createTestInstance() {
+        InferenceConfig config = null;
+
+        if (randomBoolean()) {
+            if (randomBoolean()) {
+                config = ClassificationConfigTests.randomClassificationConfig();
+            } else {
+                config = RegressionConfigTests.randomRegressionConfig();
+            }
+        }
+
+        InferenceRescorerBuilder builder = new InferenceRescorerBuilder(randomAlphaOfLength(8), config, randomMap());
+        if (randomBoolean()) {
+            builder.setQueryWeight((float) randomDoubleBetween(0.0, 1.0, true));
+            builder.setModelWeight((float) randomDoubleBetween(0.0, 2.0, true));
+            builder.setScoreMode(randomFrom(QueryRescoreMode.values()));
+        }
+
+        return builder;
+    }
+
+    private Map<String, String> randomMap() {
+        int numEntries = randomIntBetween(0, 6);
+        Map<String, String> result = new HashMap<>();
+        for (int i = 0; i < numEntries; i++) {
+            result.put("field" + i, randomAlphaOfLength(5));
+        }
+
+        return result;
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return new NamedXContentRegistry(new MlInferenceNamedXContentProvider().getNamedXContentParsers());
+    }
+
+    @Override
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(new MlInferenceNamedXContentProvider().getNamedWriteables());
+    }
+}

--- a/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/rescore.yml
+++ b/x-pack/plugin/src/test/resources/rest-api-spec/test/ml/rescore.yml
@@ -1,0 +1,102 @@
+setup:
+  - skip:
+      features: headers
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      ml.put_trained_model:
+        model_id: a-complex-regression-model
+        body: >
+          {
+            "description": "super complex model for tests",
+            "input": {"field_names": ["decider"]},
+            "definition": {
+              "trained_model": {
+                "ensemble": {
+                  "feature_names": [],
+                  "target_type": "regression",
+                  "trained_models": [
+                  {
+                    "tree": {
+                      "feature_names": [
+                        "decider"
+                      ],
+                      "tree_structure": [
+                      {
+                        "node_index": 0,
+                        "split_feature": 0,
+                        "split_gain": 12,
+                        "threshold": 38,
+                        "decision_type": "lte",
+                        "default_left": true,
+                        "left_child": 1,
+                        "right_child": 2
+                      },
+                      {
+                        "node_index": 1,
+                        "leaf_value": 5.0
+                      },
+                      {
+                        "node_index": 2,
+                        "leaf_value": 2.0
+                      }
+                      ],
+                      "target_type": "regression"
+                    }
+                  }
+                  ]
+                }
+              }
+            }
+          }
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      indices.create:
+        index: store
+        body:
+          mappings:
+            properties:
+              goods:
+                type: text
+              size:
+                type: double
+
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
+      bulk:
+        index: store
+        refresh: true
+        body: |
+          { "index": {} }
+          { "goods": "television", "size": 32.0 }
+          { "index": {} }
+          { "goods": "VCR", "size": 0 }
+          { "index": {} }
+          { "goods": "widescreen television", "size": 40.0 }
+
+---
+"Test rescore":
+
+  - do:
+      search:
+        index: store
+        body: |
+          {
+            "query": { "term" : { "goods": {"value": "television"} } },
+            "rescore": {
+              "ml_rescore" : {
+                "model_id": "a-complex-regression-model",
+                "field_mappings": {"size": "decider"},
+                "inference_config": { "regression": {} },
+                "model_weight": 2.0,
+                "query_weight": 0.0
+              }
+            }
+          }
+  - match: { hits.hits.0._score: 10.0 }
+  - match: { hits.hits.1._score: 4.0 }


### PR DESCRIPTION
**Note:** this PR is just meant for discussion and is not intended as a draft or prototype.

This PR shows how to pass in a custom service to a rescorer. It adds one commit
on top of @davidkyle's ongoing rescore prototype (#52059). 

The approach is pretty hacky. I am keeping an eye out for refactors in the search plugin
code that could make this cleaner.